### PR TITLE
RHCLOUD-46612: Remove V2 tenant binding mappings

### DIFF
--- a/rbac/internal/migrations/recompute_role_bindings.py
+++ b/rbac/internal/migrations/recompute_role_bindings.py
@@ -42,17 +42,7 @@ def _do_tear_down_tenant(tenant: Tenant, replicator: RelationReplicator):
         .select_for_update(of=["self"])
     )
 
-    binding_mapping_predicate = Q(
-        resource_type_namespace="rbac",
-        resource_type_name="tenant",
-        resource_id=tenant_resource_id,
-    ) | (
-        Q(
-            resource_type_namespace="rbac",
-            resource_type_name="workspace",
-        )
-        & In(Cast(F("resource_id"), UUIDField()), Workspace.objects.filter(tenant=tenant).values("id"))
-    )
+    binding_mapping_predicate = BindingMapping.filter_known_in_tenant(tenant)
 
     if len(role_bindings) > 0:
         binding_mapping_predicate = binding_mapping_predicate | Q(

--- a/rbac/internal/migrations/remove_v2_tenant_binding_mappings.py
+++ b/rbac/internal/migrations/remove_v2_tenant_binding_mappings.py
@@ -1,0 +1,33 @@
+import logging
+
+from django.db import transaction
+
+from api.models import Tenant
+from management.role.model import BindingMapping
+from management.tenant_mapping.v2_activation import lock_tenant_version, TenantVersion
+
+logger = logging.getLogger(__name__)
+
+
+@transaction.atomic
+def _do_remove_for(tenant: Tenant):
+    tenant_version = lock_tenant_version(tenant)
+
+    if tenant_version == TenantVersion.VERSION_1:
+        return
+
+    deleted_count, _ = BindingMapping.objects.filter(BindingMapping.filter_known_in_tenant(tenant)).delete()
+    logger.info(f"Deleted {deleted_count} BindingMappings for tenant with org_id {tenant.org_id!r}")
+
+
+def remove_v2_tenant_binding_mappings():
+    """Remove old BindingMappings for tenants that have migrated to V2."""
+    logger.info("About to remove BindingMappings for tenants that have migrated to V2.")
+
+    count = 0
+
+    for tenant in Tenant.objects.exclude(tenant_mapping__v2_write_activated_at=None).iterator():
+        _do_remove_for(tenant)
+        count += 1
+
+    logger.info(f"Removed BindingMappings for {count} V2 tenants.")

--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -131,6 +131,7 @@ urlpatterns = [
     ),
     path("api/utils/replicate_default_workspaces/", views.replicate_default_workspaces),
     path("api/utils/recompute_tenant_role_bindings/<str:org_id>/", views.recompute_tenant_role_bindings),
+    path("api/utils/remove_v2_tenant_binding_mappings/", views.remove_v2_tenant_binding_mappings),
     path("api/disaster_recovery/workspaces/", views.recover_workspace_events),
     path("api/disaster_recovery/reconcile/", views.disaster_recovery_reconcile),
 ]

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -97,6 +97,7 @@ from management.tasks import (
     recover_workspace_events_in_worker,
     remove_deleted_workspace_bindings_in_worker,
     remove_unassigned_system_binding_mappings_in_worker,
+    remove_v2_tenant_binding_mappings_in_worker,
     replicate_default_workspaces_in_worker,
     run_migrations_in_worker,
     run_ocm_performance_in_worker,
@@ -2624,6 +2625,27 @@ def recompute_tenant_role_bindings(request, org_id):
         logger.exception(f"Error recomputing role bindings for tenant {org_id}")
         return JsonResponse(
             {"detail": f"Error recomputing role bindings for tenant: {str(e)}"},
+            status=500,
+        )
+
+
+@require_http_methods(["POST"])
+def remove_v2_tenant_binding_mappings(request):
+    """
+    Remove BindingMappings for all tenants that have migrated to V2.
+
+    POST /_private/api/utils/remove_v2_tenant_binding_mappings/
+
+    Returns:
+        JSON response indicating the task has been queued
+    """
+    try:
+        remove_v2_tenant_binding_mappings_in_worker.delay()
+        return JsonResponse({"message": "Job enqueued in background worker."}, status=202)
+    except Exception as e:
+        logger.exception("Error removing BindingMappings")
+        return JsonResponse(
+            {"detail": f"Error removing BindingMappings: {str(e)}"},
             status=500,
         )
 

--- a/rbac/management/role/model.py
+++ b/rbac/management/role/model.py
@@ -23,7 +23,9 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models
-from django.db.models import signals
+from django.db.models import F, Q, UUIDField, signals
+from django.db.models.functions import Cast
+from django.db.models.lookups import In
 from django.utils import timezone
 from internal.integration import sync_handlers
 from management.cache import AccessCache, skip_purging_cache_for_public_tenant
@@ -31,6 +33,7 @@ from management.models import Permission, Principal
 from management.rbac_fields import AutoDateTimeField
 from management.relation_replicator.types import RelationTuple
 from management.role.user_source import SourceKey
+from management.workspace.model import Workspace
 from migration_tool.models import (
     V2boundresource,
     V2role,
@@ -39,7 +42,7 @@ from migration_tool.models import (
     role_binding_user_subject_tuple,
 )
 
-from api.models import FilterQuerySet, TenantAwareModel
+from api.models import FilterQuerySet, Tenant, TenantAwareModel
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -301,6 +304,24 @@ class BindingMapping(models.Model):
             raise TypeError(f"Expected SourceKey, but got: {source!r}")
 
         return source
+
+    @classmethod
+    def filter_known_in_tenant(cls, tenant: Tenant) -> Q:
+        """
+        Return a filter for BindingMappings that are locally known to be in the provided tenant.
+
+        This will only include bindings to the tenant itself and to its workspaces, since those are the only
+        resources we can know are in the tenant while consulting only RBAC's database.
+        """
+        resource_id = tenant.tenant_resource_id()
+
+        if resource_id is None:
+            raise ValueError(f"Tenants without a resource ID are not supported, but got pk={tenant.pk!r}")
+
+        return Q(resource_type_namespace="rbac", resource_type_name="tenant", resource_id=resource_id) | (
+            Q(resource_type_namespace="rbac", resource_type_name="workspace")
+            & In(Cast(F("resource_id"), UUIDField()), Workspace.objects.filter(tenant=tenant).values("id"))
+        )
 
 
 def role_related_obj_change_cache_handler(sender=None, instance=None, using=None, **kwargs):

--- a/rbac/management/tasks.py
+++ b/rbac/management/tasks.py
@@ -29,6 +29,7 @@ from django.core.management import call_command
 from internal.migrations.recompute_role_bindings import recompute_tenant_role_bindings
 from internal.migrations.remove_deleted_workspace_bindings import remove_deleted_workspace_bindings
 from internal.migrations.remove_orphan_relations import cleanup_tenant_orphan_bindings
+from internal.migrations.remove_v2_tenant_binding_mappings import remove_v2_tenant_binding_mappings
 from internal.migrations.replicate_default_workspaces import replicate_default_workspaces
 from internal.utils import (
     clean_invalid_workspace_resource_definitions,
@@ -199,6 +200,12 @@ def replicate_default_workspaces_in_worker(limit: Optional[int] = None):
 def recompute_tenant_role_bindings_in_worker(org_id: str):
     """Celery task to recompute role bindings for tenant."""
     return recompute_tenant_role_bindings(tenant=Tenant.objects.get(org_id=org_id))
+
+
+@shared_task
+def remove_v2_tenant_binding_mappings_in_worker():
+    """Celery task to remove BindingMappings for V2 tenants."""
+    return remove_v2_tenant_binding_mappings()
 
 
 @shared_task

--- a/rbac/management/tenant_mapping/v2_activation.py
+++ b/rbac/management/tenant_mapping/v2_activation.py
@@ -39,9 +39,17 @@ Usage:
 
 import enum
 import logging
+from typing import Optional
 
 from django.db import connection
+from django.db.models import UUIDField
+from django.db.models.fields.json import KT
+from django.db.models.functions import Cast
+from django.db.models.lookups import In
 from django.utils import timezone
+from management.atomic_transactions import atomic
+from management.role.model import BindingMapping
+from management.role_binding.model import RoleBinding
 from management.tenant_mapping.model import TenantMapping
 from management.tenant_service.v2 import TenantNotBootstrappedError
 
@@ -78,6 +86,46 @@ class V1WriteBlockedError(Exception):
     pass
 
 
+def _remove_tenant_binding_mappings(tenant: Tenant, tenant_mapping: TenantMapping):
+    """Remove all BindingMappings within a tenant about to be migrated."""
+    if tenant_mapping.tenant_id != tenant.id:
+        raise ValueError(f"Tenant/TenantMapping mismatch: {tenant.id!r} vs. {tenant_mapping.tenant_id!r}")
+
+    binding_uuids = list(
+        RoleBinding.objects.filter(tenant=tenant)
+        .exclude(uuid__in=tenant_mapping.role_binding_ids())
+        .select_for_update()
+        .values_list("uuid", flat=True)
+    )
+
+    _, delete_result = BindingMapping.objects.filter(In(Cast(KT("mappings__id"), UUIDField()), binding_uuids)).delete()
+    actual_removed = delete_result.get("management.BindingMapping", 0)
+
+    # If a tenant is being migrated to V2, we expect that there should not yet be any RoleBindings within it that
+    # do not have a corresponding BindingMapping (other than default-access RoleBindings). So, the number of
+    # BindingMappings that we just removed should be the same as the number of RoleBindings we found.
+
+    if actual_removed != len(binding_uuids):
+        raise AssertionError(f"Expected to delete {len(binding_uuids)} BindingMappings, but removed {actual_removed}")
+
+    # Conversely, for a tenant being migrated, we also expect that all BindingMappings in the tenant have
+    # corresponding RoleBindings. We've just deleted every BindingMapping that corresponds to a RoleBinding within
+    # the tenant, so there should be no BindingMappings left within the tenant. (We can only easily check this for
+    # resources that we locally know to be within the tenant, so that's what we do.)
+
+    remaining_mappings = list(BindingMapping.objects.filter(BindingMapping.filter_known_in_tenant(tenant)))
+
+    if remaining_mappings:
+        raise AssertionError(
+            f"Found BindingMappings unexpectedly remaining within tenant: pks={[m.pk for m in remaining_mappings]}"
+        )
+
+    logger.info(
+        f"Removed {actual_removed} BindingMappings during V2 migration of tenant with org_id {tenant.org_id!r}"
+    )
+
+
+@atomic
 def ensure_v2_write_activated(tenant: Tenant):
     """Mark the tenant as V2-activated if not already. Must be called inside a transaction.
 
@@ -90,16 +138,23 @@ def ensure_v2_write_activated(tenant: Tenant):
     if v2_activated is not None:
         return
 
-    mapping = TenantMapping.objects.select_for_update().filter(tenant=tenant).first()
+    mapping: Optional[TenantMapping] = TenantMapping.objects.select_for_update().filter(tenant=tenant).first()
+
     if mapping is None:
         raise TenantNotBootstrappedError(
             f"Tenant {tenant.org_id} has no TenantMapping; V2 writes require tenant bootstrapping."
         )
+
     if mapping.v2_write_activated_at is not None:
         return
 
     mapping.v2_write_activated_at = timezone.now()
     mapping.save(update_fields=["v2_write_activated_at"])
+
+    # Once a tenant has been migrated to V2, its BindingMappings are immediately out of date and should no longer be
+    # referenced, so we can remove them.
+    _remove_tenant_binding_mappings(tenant=tenant, tenant_mapping=mapping)
+
     logger.info("Tenant %s activated for V2 writes", tenant.org_id)
 
 

--- a/tests/internal/migrations/test_remove_v2_tenant_binding_mappings.py
+++ b/tests/internal/migrations/test_remove_v2_tenant_binding_mappings.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from internal.migrations.remove_v2_tenant_binding_mappings import remove_v2_tenant_binding_mappings
+from management.role.model import BindingMapping
+from management.tenant_mapping.v2_activation import ensure_v2_write_activated
+from migration_tool.in_memory_tuples import InMemoryRelationReplicator
+from tests.management.role.test_dual_write import DualWriteTestCase
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class TestRemoveV2TenantBindingMappings(DualWriteTestCase):
+    @patch("management.relation_replicator.outbox_replicator.OutboxReplicator.replicate")
+    def test_migration(self, mock_replicate):
+        mock_replicate.side_effect = InMemoryRelationReplicator(self.tuples).replicate
+
+        system_role = self.given_v1_system_role("system role", ["rbac:*:*"])
+        custom_role = self.given_v1_role("custom role", default=["rbac:*:*"], **{self.ws_1_id: ["inventory:*:*"]})
+
+        group, _ = self.given_group("group", ["p1"])
+        self.given_roles_assigned_to_group(group, [system_role, custom_role])
+
+        mapping_query = BindingMapping.objects.filter(role__in=[system_role, custom_role])
+
+        prior_mappings = list(mapping_query.all())
+        self.assertEqual(len(prior_mappings), 3)
+
+        ensure_v2_write_activated(self.tenant)
+
+        # Emulate the BindingMappings not being removed during an old version of V1-to-V2 conversion.
+        for mapping in prior_mappings:
+            mapping.save(force_insert=True)
+
+        self.assertEqual(mapping_query.all().count(), 3)
+        initial_tuples = set(self.tuples)
+
+        remove_v2_tenant_binding_mappings()
+
+        self.assertEqual(mapping_query.all().count(), 0)
+        self.assertSetEqual(set(self.tuples), initial_tuples)

--- a/tests/internal/test_migrate_binding_scope_api.py
+++ b/tests/internal/test_migrate_binding_scope_api.py
@@ -530,6 +530,7 @@ class BindingScopeMigrationTupleVerificationTest(TestCase):
         assert_v2_tuples_consistent(test=self, tuples=self.tuples)
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class SystemRoleBindingMigrationTest(TestCase):
     """Tests for system role binding migration via group operations."""
 

--- a/tests/internal/test_utils.py
+++ b/tests/internal/test_utils.py
@@ -918,10 +918,11 @@ class RemoveOrphanBindingMappingsTest(DualWriteTestCase):
         self.assertEqual(set(self.tuples), tuples_before)
 
     def test_no_remove_v2_tenant(self):
+        ensure_v2_write_activated(self.tenant)
+
+        # Emulate the BindingMapping not being removed during an old version of V1-to-V2 conversion.
         role, binding_mapping = self._create_empty_binding_mapping()
         tuples_before = set(self.tuples)
-
-        ensure_v2_write_activated(self.tenant)
 
         self._do_remove_empty()
 
@@ -1075,8 +1076,12 @@ class ExpireOrphanCrossAccountRequests(DualWriteTestCase):
 
     def test_preserve_v2_tenant(self):
         car = self.given_car(self.source_user_id, [self.role])
+        binding_mapping = BindingMapping.objects.get(role=self.role)
 
         ensure_v2_write_activated(self.tenant)
+
+        # Emulate the BindingMapping not being removed during an old version of V1-to-V2 conversion.
+        binding_mapping.save(force_insert=True)
 
         def expect_exists():
             self.expect_1_role_binding_to_workspace(

--- a/tests/management/management/commands/test_fix_orphan_relations.py
+++ b/tests/management/management/commands/test_fix_orphan_relations.py
@@ -342,7 +342,12 @@ class TestRemoveOrphanRelations(DualWriteTestCase):
         # NoopReplicator.
 
         service = RoleBindingService(tenant=self.tenant, replicator=NoopReplicator())
+        binding_mapping = BindingMapping.objects.filter(role=target_role).get()
+
         ensure_v2_write_activated(self.tenant)
+
+        # Emulate the BindingMapping not being removed during an old version of V1-to-V2 conversion.
+        binding_mapping.save(force_insert=True)
 
         def assert_role_bindings(v1_count: int, v2_count: int, tuples_count: int):
             self.assertEqual(v1_count, BindingMapping.objects.filter(role=target_role).count())

--- a/tests/management/role/test_dual_write.py
+++ b/tests/management/role/test_dual_write.py
@@ -596,7 +596,9 @@ class DualWriteTestCase(TestCase):
         self.assertCountEqual(entries, actual)
 
 
-@override_settings(ROOT_SCOPE_PERMISSIONS="root:*:*", TENANT_SCOPE_PERMISSIONS="tenant:*:*")
+@override_settings(
+    ATOMIC_RETRY_DISABLED=True, ROOT_SCOPE_PERMISSIONS="root:*:*", TENANT_SCOPE_PERMISSIONS="tenant:*:*"
+)
 class DualWriteGroupTestCase(DualWriteTestCase):
     """Test dual write logic for group modifications."""
 
@@ -2155,6 +2157,7 @@ class DualWriteSystemRolesTestCase(DualWriteTestCase):
             self.assertEqual(len(deleted_tuple), 0)
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class DualWriteCustomRolesTestCase(DualWriteTestCase):
     """Test dual write logic when we are working with custom roles."""
 

--- a/tests/management/role_binding/test_view.py
+++ b/tests/management/role_binding/test_view.py
@@ -47,10 +47,12 @@ from management.role_binding.model import RoleBinding, RoleBindingGroup, RoleBin
 from management.role_binding.service import RoleBindingService, API_PRINCIPAL_SOURCE
 from management.subject import SubjectType
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping
+from management.tenant_mapping.v2_activation import ensure_v2_write_activated
 from management.tenant_service.v2 import V2TenantBootstrapService
 from migration_tool.in_memory_tuples import InMemoryRelationReplicator
 from rbac import urls
 from tests.identity_request import IdentityRequest, TransactionalIdentityRequest
+from tests.v2_util import bootstrap_tenant_for_v2_test
 
 
 def _coerce_api_datetime(value):
@@ -1565,18 +1567,13 @@ class RoleBindingViewSetTest(IdentityRequest):
         super().setUp()
         self.client = APIClient()
 
-        # Create workspace hierarchy (root -> default -> standard)
-        self.root_workspace = Workspace.objects.create(
-            name=Workspace.SpecialNames.ROOT,
-            tenant=self.tenant,
-            type=Workspace.Types.ROOT,
-        )
-        self.default_workspace = Workspace.objects.create(
-            name=Workspace.SpecialNames.DEFAULT,
-            tenant=self.tenant,
-            type=Workspace.Types.DEFAULT,
-            parent=self.root_workspace,
-        )
+        bootstrap_result = bootstrap_tenant_for_v2_test(self.tenant)
+        self.root_workspace = bootstrap_result.root_workspace
+        self.default_workspace = bootstrap_result.default_workspace
+
+        # We will be creating a bindings without V1 representations below, meaning this tenant must be V2.
+        ensure_v2_write_activated(self.tenant)
+
         self.workspace = Workspace.objects.create(
             name="Test Workspace",
             description="Test workspace description",
@@ -1584,9 +1581,6 @@ class RoleBindingViewSetTest(IdentityRequest):
             type=Workspace.Types.STANDARD,
             parent=self.default_workspace,
         )
-
-        # TenantMapping required for V2 write operations (e.g. PUT by-subject)
-        TenantMapping.objects.get_or_create(tenant=self.tenant, defaults={})
 
         # Create permission and role
         self.permission = Permission.objects.create(

--- a/tests/management/tenant_mapping/test_v2_activation.py
+++ b/tests/management/tenant_mapping/test_v2_activation.py
@@ -22,10 +22,13 @@ from django.test import TestCase, override_settings
 from django.db import transaction
 
 from api.models import Tenant
+from management.group.definer import seed_group
 from management.group.model import Group
 from management.relation_replicator.noop_replicator import NoopReplicator
+from management.role.definer import seed_roles
 from management.role.model import BindingMapping, Role
 from management.role_binding.model import RoleBinding
+from management.role_binding.service import RoleBindingService
 from management.tenant_mapping.model import TenantMapping
 from management.tenant_mapping.v2_activation import (
     V1WriteBlockedError,
@@ -195,6 +198,29 @@ class V2ActivationBindingRemovalTest(DualWriteTestCase):
 
         self.assertSetEqual(initial_tuples, set(self.tuples))
         self._expect_binding_counts(self.custom_role, 0, 2)
+
+    def test_remove_with_default_access_bindings(self):
+        self.given_roles_assigned_to_group(self.group, [self.system_role])
+
+        initial_tuples = set(self.tuples)
+        self._expect_binding_counts(self.system_role, 1, 1)
+
+        # Platform roles and groups are needed for default-access RoleBindings.
+        seed_roles()
+        seed_group()
+
+        # Do this solely for the side-effect of creating default-access RoleBindings.
+        RoleBindingService(tenant=self.tenant).get_role_bindings_by_subject(
+            {"resource_type": "workspace", "resource_id": self.default_workspace()}
+        )
+
+        # Verify that we succeeded in creating them.
+        self.assertTrue(RoleBinding.objects.filter(uuid__in=self.tenant.tenant_mapping.role_binding_ids()).exists())
+
+        ensure_v2_write_activated(self.tenant)
+
+        self.assertSetEqual(initial_tuples, set(self.tuples))
+        self._expect_binding_counts(self.system_role, 0, 1)
 
     def test_fail_missing_binding_mapping(self):
         self.given_roles_assigned_to_group(self.group, [self.system_role])

--- a/tests/management/tenant_mapping/test_v2_activation.py
+++ b/tests/management/tenant_mapping/test_v2_activation.py
@@ -16,10 +16,16 @@
 #
 """Tests for V2 write activation state."""
 
-from django.test import TestCase
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
 from django.db import transaction
 
 from api.models import Tenant
+from management.group.model import Group
+from management.relation_replicator.noop_replicator import NoopReplicator
+from management.role.model import BindingMapping, Role
+from management.role_binding.model import RoleBinding
 from management.tenant_mapping.model import TenantMapping
 from management.tenant_mapping.v2_activation import (
     V1WriteBlockedError,
@@ -30,13 +36,27 @@ from management.tenant_mapping.v2_activation import (
     TenantVersion,
 )
 from management.tenant_service.v2 import TenantNotBootstrappedError
-from tests.management.role.test_dual_write import RbacFixture
+from management.workspace.service import WorkspaceService
+from migration_tool.in_memory_tuples import (
+    InMemoryTuples,
+    InMemoryRelationReplicator,
+    all_of,
+    resource,
+    relation,
+    subject,
+)
+from tests.management.role.test_dual_write import RbacFixture, DualWriteTestCase
+from tests.util import assert_v2_tuples_consistent
+from tests.v2_util import bootstrap_tenant_for_v2_test
 
 
+@override_settings(ATOMIC_RETRY_DISABLED=True)
 class V2ActivationTests(TestCase):
     """Tests for V2 activation functions."""
 
     def setUp(self):
+        super().setUp()
+
         self.fixture = RbacFixture()
         self.bootstrapped = self.fixture.new_tenant(org_id="activation-test-org")
         self.tenant = self.bootstrapped.tenant
@@ -119,3 +139,73 @@ class V2ActivationTests(TestCase):
         with self.assertRaises(TenantNotBootstrappedError):
             with transaction.atomic():
                 lock_tenant_version(unbootstrapped)
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class V2ActivationBindingRemovalTest(DualWriteTestCase):
+    def setUp(self):
+        super().setUp()
+        bootstrap_tenant_for_v2_test(self.tenant, tuples=self.tuples)
+
+        self.group, _ = self.given_group("group", ["p1"])
+
+        self.system_role = self.given_v1_system_role("a role", ["rbac:*:*"])
+        self.custom_role = self.given_v1_role("a role", default=["rbac:*:*"], **{self.ws_1_id: ["inventory:*:*"]})
+
+    def tearDown(self):
+        assert_v2_tuples_consistent(test=self, tuples=self.tuples)
+        super().tearDown()
+
+    def _expect_binding_counts(self, role: Role, v1_count: int, v2_count: int):
+        self.assertEqual(v1_count, BindingMapping.objects.filter(role=role).count())
+
+        role_bindings = list(RoleBinding.objects.filter(role__v1_source=role))
+        self.assertEqual(v2_count, len(role_bindings))
+
+        for binding in role_bindings:
+            self.assertEqual(
+                1,
+                self.tuples.count_tuples(
+                    all_of(
+                        resource("rbac", "role_binding", str(binding.uuid)),
+                        relation("role"),
+                        subject("rbac", "role", str(binding.role.uuid)),
+                    )
+                ),
+            )
+
+    def test_remove_system_binding(self):
+        self.given_roles_assigned_to_group(self.group, [self.system_role])
+
+        initial_tuples = set(self.tuples)
+        self._expect_binding_counts(self.system_role, 1, 1)
+
+        ensure_v2_write_activated(self.tenant)
+
+        self.assertSetEqual(initial_tuples, set(self.tuples))
+        self._expect_binding_counts(self.system_role, 0, 1)
+
+    def test_remove_custom_bindings(self):
+        self.given_roles_assigned_to_group(self.group, [self.custom_role])
+
+        initial_tuples = set(self.tuples)
+        self._expect_binding_counts(self.custom_role, 2, 2)
+
+        ensure_v2_write_activated(self.tenant)
+
+        self.assertSetEqual(initial_tuples, set(self.tuples))
+        self._expect_binding_counts(self.custom_role, 0, 2)
+
+    def test_fail_missing_binding_mapping(self):
+        self.given_roles_assigned_to_group(self.group, [self.system_role])
+        BindingMapping.objects.filter(role=self.system_role).delete()
+
+        with self.assertRaises(AssertionError):
+            ensure_v2_write_activated(self.tenant)
+
+    def test_fail_missing_role_binding(self):
+        self.given_roles_assigned_to_group(self.group, [self.system_role])
+        RoleBinding.objects.filter(role__v1_source=self.system_role).delete()
+
+        with self.assertRaises(AssertionError):
+            ensure_v2_write_activated(self.tenant)

--- a/tests/management/workspace/test_service.py
+++ b/tests/management/workspace/test_service.py
@@ -509,7 +509,12 @@ class WorkspaceServiceDestroyTests(WorkspaceServiceTestBase):
         group_handler.generate_relations_reset_roles([custom_role])
         group_handler.replicate()
 
+        binding_mapping = BindingMapping.objects.get(role=custom_role)
+
         ensure_v2_write_activated(self.tenant)
+
+        # Emulate the BindingMapping not being removed during an old version of V1-to-V2 conversion.
+        binding_mapping.save(force_insert=True)
 
         def assert_binding_exists(value: bool):
             self.assertEqual(

--- a/tests/util/v2_local_invariants.py
+++ b/tests/util/v2_local_invariants.py
@@ -70,7 +70,13 @@ def _assert_v1_v2_system_roles_locally_consistent(test: TestCase):
         str(m.mappings["id"]): m for m in BindingMapping.objects.filter(role__system=True).prefetch_related("role")
     }
 
-    role_bindings_by_uuid = {str(b.uuid): b for b in RoleBinding.objects.filter(role__type=RoleV2.Types.SEEDED)}
+    # Role bindings in V2 tenants will not have corresponding BindingMappings, so we exclude them.
+    role_bindings_by_uuid = {
+        str(b.uuid): b
+        for b in RoleBinding.objects.filter(role__type=RoleV2.Types.SEEDED).filter(
+            tenant__tenant_mapping__v2_write_activated_at=None
+        )
+    }
 
     # We should have the same UUIDs for both BindingMappings and RoleBindings.
     test.assertCountEqual(role_bindings_by_uuid.keys(), binding_mappings_by_uuid.keys())
@@ -84,7 +90,13 @@ def _assert_v1_v2_custom_roles_locally_consistent(test: TestCase):
         str(m.mappings["id"]): m for m in BindingMapping.objects.filter(role__system=False).prefetch_related("role")
     }
 
-    role_bindings_by_uuid = {str(b.uuid): b for b in RoleBinding.objects.filter(role__type=RoleV2.Types.CUSTOM)}
+    # Role bindings in V2 tenants will not have corresponding BindingMappings, so we exclude them.
+    role_bindings_by_uuid = {
+        str(b.uuid): b
+        for b in RoleBinding.objects.filter(role__type=RoleV2.Types.CUSTOM).filter(
+            tenant__tenant_mapping__v2_write_activated_at=None
+        )
+    }
 
     # We should have the same UUIDs for both BindingMappings and RoleBindings.
     test.assertCountEqual(role_bindings_by_uuid.keys(), binding_mappings_by_uuid.keys())
@@ -92,7 +104,8 @@ def _assert_v1_v2_custom_roles_locally_consistent(test: TestCase):
     for role in Role.objects.filter(system=False):
         _assert_v2_names(test, role)
 
-    for role in CustomRoleV2.objects.all():
+    # Roles in V2 tenants will not necessarily have consistent BindingMappings.
+    for role in CustomRoleV2.objects.filter(tenant__tenant_mapping__v2_write_activated_at=None):
         test.assertIsNotNone(role.v1_source, "All custom roles created through dual-write should have a v1_source.")
 
         _assert_role_mappings_consistent(


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-46612](https://redhat.atlassian.net/browse/RHCLOUD-46612)

## Description of Intent of Change(s)
Remove `BindingMapping`s for a tenant when migrating it to V2, and add a migration to do this for tenants that have already migrated.

[RHCLOUD-46612]: https://redhat.atlassian.net/browse/RHCLOUD-46612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove obsolete BindingMappings when tenants migrate to V2 and provide a migration and internal endpoint to clean up remaining mappings for already-migrated tenants.

Bug Fixes:
- Ensure V2 activation deletes all BindingMappings for the tenant’s non-default-access RoleBindings and fails loudly if mappings and bindings are inconsistent.

Enhancements:
- Add tenant-scoped query helper for locating BindingMappings known to belong to a tenant and reuse it in existing recompute logic.
- Expose an internal API and background task to trigger cleanup of BindingMappings for all tenants that are already V2-activated.
- Adjust V2 consistency checks to ignore V2 tenants where BindingMappings are no longer expected.

Tests:
- Add unit and integration tests around V2 activation binding removal, the new migration utility, and existing utilities to cover scenarios where legacy BindingMappings still exist after V2 migration.
- Update role binding, workspace, and management command tests to account for BindingMapping removal on V2 activation and to simulate old-tenant states for regression coverage.