### PR TITLE
feat(role-bindings): route tenant access through Kessel behind feature flag [RHCLOUD-46266]

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -750,6 +750,8 @@ objects:
             value: ${V2_READ_ONLY_API_MODE}
           - name: V2_EDIT_API_ENABLED
             value: ${V2_EDIT_API_ENABLED}
+          - name: KESSEL_TENANT_AUTH_ENABLED
+            value: ${KESSEL_TENANT_AUTH_ENABLED}
           - name: V1_ROLE_PERMISSION_BLOCK_LIST
             value: ${V1_ROLE_PERMISSION_BLOCK_LIST}
           - name: READ_ONLY_API_MODE
@@ -1933,6 +1935,9 @@ parameters:
   value: 'False'
 - name: V2_EDIT_API_ENABLED
   description: Fallback for feature flag to enable v2 edit APIs and block v1 write APIs per org
+  value: 'False'
+- name: KESSEL_TENANT_AUTH_ENABLED
+  description: Route tenant-level role binding access checks through Kessel instead of org-admin middleware
   value: 'False'
 - name: V1_ROLE_PERMISSION_BLOCK_LIST
   description: Comma-separated list of exact permission strings to hide from v1 API (e.g., rbac:role:read,rbac:group:write)

--- a/rbac/management/permissions/role_binding_access.py
+++ b/rbac/management/permissions/role_binding_access.py
@@ -20,6 +20,7 @@
 import logging
 import uuid
 
+from django.conf import settings
 from feature_flags import FEATURE_FLAGS
 from management.permissions.workspace_inventory_access import (
     WorkspaceInventoryAccessChecker,
@@ -186,7 +187,8 @@ class RoleBindingKesselAccessPermission(permissions.BasePermission):
 
         When a read request (list, by_subject, etc.) omits resource_id/resource_type
         query parameters, this method falls back to a tenant-level permission check.
-        Only users with org admin access on the tenant resource are allowed.
+        When KESSEL_TENANT_AUTH_ENABLED is off, only org admins are allowed.
+        When on, the check is delegated to Kessel.
         """
         tenant = getattr(request, "tenant", None)
         if tenant is None:
@@ -258,7 +260,9 @@ class RoleBindingKesselAccessPermission(permissions.BasePermission):
             return self._check_single_resource(request, resource_type, resource_id, self.EDIT_RELATION)
 
     def _resolve_principal_id(self, request, unique_resources):
-        """Resolve principal_id once if any non-tenant resources need Kessel checks."""
+        """Resolve principal_id once if any resources need Kessel checks."""
+        if settings.KESSEL_TENANT_AUTH_ENABLED:
+            return get_kessel_principal_id(request)
         needs_kessel = any(rt != "tenant" for rt, _ in unique_resources)
         if needs_kessel:
             return get_kessel_principal_id(request)
@@ -314,23 +318,6 @@ class RoleBindingKesselAccessPermission(permissions.BasePermission):
             self._validate_workspace_exists(request, resource_id)
 
         if resource_type == "tenant":
-            is_org_admin = getattr(request.user, "admin", False)
-            if not is_org_admin:
-                # Authorization failure - SEC-MON-REQ-1 compliance
-                # (EOI-8 authorization_failure, EOI-4 access_manipulation)
-                logger.warning(
-                    "Authorization denied",
-                    extra={
-                        "action": request.method,
-                        "resource_type": "role_binding",
-                        "outcome": "failure",
-                        "org_id": getattr(request.user, "org_id", None),
-                        "username": getattr(request.user, "username", None),
-                        "reason": "not_org_admin_for_tenant_resource",
-                        "endpoint": request.path,
-                    },
-                )
-                return False
             tenant = getattr(request, "tenant", None)
             if tenant is None:
                 logger.debug("Denied access for tenant resource: no tenant on request")
@@ -343,7 +330,24 @@ class RoleBindingKesselAccessPermission(permissions.BasePermission):
                     expected_resource_id,
                 )
                 return False
-            return True
+
+            if not settings.KESSEL_TENANT_AUTH_ENABLED:
+                is_org_admin = getattr(request.user, "admin", False)
+                if not is_org_admin:
+                    logger.warning(
+                        "Authorization denied",
+                        extra={
+                            "action": request.method,
+                            "resource_type": "role_binding",
+                            "outcome": "failure",
+                            "org_id": getattr(request.user, "org_id", None),
+                            "username": getattr(request.user, "username", None),
+                            "reason": "not_org_admin_for_tenant_resource",
+                            "endpoint": request.path,
+                        },
+                    )
+                    return False
+                return True
 
         if principal_id is None:
             principal_id = get_kessel_principal_id(request)
@@ -357,8 +361,8 @@ class RoleBindingKesselAccessPermission(permissions.BasePermission):
             principal_id=principal_id,
             relation=relation,
         )
+        # Authorization failure - SEC-MON-REQ-1 compliance (EOI-8 authorization_failure, EOI-4 access_manipulation)
         if not has_access:
-            # Authorization failure - SEC-MON-REQ-1 compliance (EOI-8 authorization_failure, EOI-4 access_manipulation)
             logger.warning(
                 "Authorization denied",
                 extra={

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -682,6 +682,8 @@ V2_READ_ONLY_API_MODE = ENVIRONMENT.bool("V2_READ_ONLY_API_MODE", default=False)
 WORKSPACE_ACCESS_CHECK_V2_ENABLED = ENVIRONMENT.bool("WORKSPACE_ACCESS_CHECK_V2_ENABLED", default=False)
 # When True, use 'role_binding_view' permission; when False, use 'view' permission for role binding access
 USE_ROLE_BINDING_VIEW_PERMISSION = ENVIRONMENT.bool("USE_ROLE_BINDING_VIEW_PERMISSION", default=True)
+# When True, tenant-level role binding access checks use Kessel instead of org-admin middleware
+KESSEL_TENANT_AUTH_ENABLED = ENVIRONMENT.bool("KESSEL_TENANT_AUTH_ENABLED", default=False)
 READ_ONLY_API_MODE = ENVIRONMENT.get_value("READ_ONLY_API_MODE", default=False)
 V2_EDIT_API_ENABLED = ENVIRONMENT.bool("V2_EDIT_API_ENABLED", default=False)
 V2_STRICT_ACCESS_CHECK_FLAG_APPLICATION_NAMES = [

--- a/tests/management/role_binding/test_role_binding_access.py
+++ b/tests/management/role_binding/test_role_binding_access.py
@@ -109,6 +109,25 @@ class RoleBindingAccessTestMixin:
         mock_inventory_client.return_value.__enter__.return_value = mock_stub
         return mock_stub, mock_response
 
+    def _make_mock_request(self, admin=False, system=False, resource_id=None, resource_type=None):
+        """Create a mock request with common defaults for permission unit tests."""
+        mock_request = Mock()
+        mock_request.user.system = system
+        mock_request.user.admin = admin
+        query_params = {}
+        if resource_id is not None:
+            query_params["resource_id"] = str(resource_id)
+        if resource_type is not None:
+            query_params["resource_type"] = resource_type
+        mock_request.query_params = query_params
+        return mock_request
+
+    def _make_mock_view(self, action="by_subject"):
+        """Create a mock view with the specified action."""
+        mock_view = Mock()
+        mock_view.action = action
+        return mock_view
+
 
 @override_settings(V2_APIS_ENABLED=True)
 class RoleBindingAccessIntegrationTests(RoleBindingAccessTestMixin, TransactionIdentityRequest):
@@ -760,6 +779,7 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
         mock_get_principal_id.assert_not_called()
         mock_checker_class.assert_not_called()
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
     def test_kessel_permission_allows_tenant_resource_type_when_org_admin(self, mock_checker_class):
         """Tenant resource type: org admin allowed without Kessel check."""
@@ -786,6 +806,7 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
         self.assertTrue(result)
         mock_checker.check_resource_access.assert_not_called()
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_kessel_permission_denies_tenant_when_not_org_admin(self):
         """Tenant resource type: non-org-admin denied."""
         permission = RoleBindingKesselAccessPermission()
@@ -941,35 +962,6 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
 
         self.assertFalse(result)
 
-    def _make_mock_request(self, admin=False, system=False, resource_id=None, resource_type=None):
-        """Create a mock request with common defaults for permission unit tests.
-
-        Args:
-            admin: Whether user is org admin (default: False).
-            system: Whether user is a system user (default: False).
-            resource_id: Optional resource_id query param.
-            resource_type: Optional resource_type query param.
-
-        Returns:
-            Mock request object. Set .tenant separately when needed.
-        """
-        mock_request = Mock()
-        mock_request.user.system = system
-        mock_request.user.admin = admin
-        query_params = {}
-        if resource_id is not None:
-            query_params["resource_id"] = str(resource_id)
-        if resource_type is not None:
-            query_params["resource_type"] = resource_type
-        mock_request.query_params = query_params
-        return mock_request
-
-    def _make_mock_view(self, action="by_subject"):
-        """Create a mock view with the specified action."""
-        mock_view = Mock()
-        mock_view.action = action
-        return mock_view
-
     def test_kessel_permission_rejects_invalid_uuid_resource_id(self):
         """Workspace resource_id must be a valid UUID; invalid values return 400."""
         from rest_framework.exceptions import ParseError
@@ -1028,6 +1020,7 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
         result = permission.has_permission(mock_request, self._make_mock_view())
         self.assertTrue(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_list_without_resource_params_denied_for_non_admin(self):
         """List endpoint without resource params should deny non-admin users."""
         permission = RoleBindingKesselAccessPermission()
@@ -1038,6 +1031,7 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
 
         self.assertFalse(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_list_without_resource_params_allowed_for_org_admin(self):
         """List endpoint without resource params should allow org admin."""
         permission = RoleBindingKesselAccessPermission()
@@ -1048,6 +1042,7 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
 
         self.assertTrue(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_by_subject_without_resource_params_denied_for_non_admin(self):
         """by_subject GET without resource params should deny non-admin users."""
         permission = RoleBindingKesselAccessPermission()
@@ -1058,6 +1053,7 @@ class RoleBindingKesselPermissionTests(RoleBindingAccessTestMixin, TransactionId
 
         self.assertFalse(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_by_subject_without_resource_params_allowed_for_org_admin(self):
         """by_subject GET without resource params should allow org admin."""
         permission = RoleBindingKesselAccessPermission()
@@ -1749,6 +1745,7 @@ class RoleBindingBatchCreatePermissionTests(RoleBindingAccessTestMixin, Transact
         self.assertIn("workspace", str(ctx.exception.detail))
         mock_checker_class.return_value.check_resource_access.assert_not_called()
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_batch_create_tenant_resource_requires_org_admin(self):
         """batch_create with tenant resource should require org admin."""
         permission = RoleBindingKesselAccessPermission()
@@ -1773,6 +1770,7 @@ class RoleBindingBatchCreatePermissionTests(RoleBindingAccessTestMixin, Transact
 
         self.assertFalse(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_batch_create_tenant_resource_allowed_for_org_admin(self):
         """batch_create with tenant resource should allow org admin."""
         permission = RoleBindingKesselAccessPermission()
@@ -1797,6 +1795,7 @@ class RoleBindingBatchCreatePermissionTests(RoleBindingAccessTestMixin, Transact
 
         self.assertTrue(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     @patch("management.permissions.role_binding_access.get_kessel_principal_id")
     @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
     def test_batch_create_tenant_only_does_not_call_kessel(self, mock_checker_class, mock_get_principal_id):
@@ -1985,6 +1984,7 @@ class RoleBindingBySubjectWritePermissionTests(RoleBindingAccessTestMixin, Trans
         self.assertIn("workspace", str(ctx.exception.detail))
         mock_checker_class.assert_not_called()
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
     @patch("management.permissions.role_binding_access.FEATURE_FLAGS")
     def test_put_by_subject_tenant_flag_enabled_denies_non_admin(self, mock_feature_flags, mock_checker_class):
@@ -2001,6 +2001,7 @@ class RoleBindingBySubjectWritePermissionTests(RoleBindingAccessTestMixin, Trans
         self.assertFalse(result)
         mock_checker_class.assert_not_called()
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
     @patch("management.permissions.role_binding_access.FEATURE_FLAGS")
     def test_put_by_subject_tenant_flag_enabled_allows_admin(self, mock_feature_flags, mock_checker_class):
@@ -2055,6 +2056,7 @@ class RoleBindingBySubjectWritePermissionTests(RoleBindingAccessTestMixin, Trans
         call_kwargs = mock_checker.check_resource_access.call_args[1]
         self.assertEqual(call_kwargs["relation"], "edit")
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     def test_put_by_subject_tenant_resource_requires_org_admin(self):
         """PUT by_subject with tenant resource should require org admin."""
         permission = RoleBindingKesselAccessPermission()
@@ -2074,6 +2076,7 @@ class RoleBindingBySubjectWritePermissionTests(RoleBindingAccessTestMixin, Trans
 
         self.assertFalse(result)
 
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
     @patch("management.permissions.role_binding_access.FEATURE_FLAGS")
     def test_put_by_subject_tenant_resource_allowed_for_org_admin(self, mock_feature_flags):
         """PUT by_subject with tenant resource should allow org admin."""
@@ -2094,3 +2097,289 @@ class RoleBindingBySubjectWritePermissionTests(RoleBindingAccessTestMixin, Trans
         result = permission.has_permission(mock_request, self._make_by_subject_put_view())
 
         self.assertTrue(result)
+
+
+@override_settings(V2_APIS_ENABLED=True)
+class RoleBindingKesselTenantAuthTests(RoleBindingAccessTestMixin, TransactionIdentityRequest):
+    """Tests for KESSEL_TENANT_AUTH_ENABLED feature flag.
+
+    When the flag is enabled, tenant-level access checks go through Kessel
+    (WorkspaceInventoryAccessChecker) instead of the org-admin middleware shortcut.
+    """
+
+    # -- Flag OFF: existing behavior unchanged --
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
+    def test_flag_off_tenant_allows_org_admin(self):
+        """With flag off, tenant access still uses org-admin check (existing behavior)."""
+        permission = RoleBindingKesselAccessPermission()
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=True, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertTrue(result)
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
+    def test_flag_off_tenant_denies_non_admin(self):
+        """With flag off, tenant access denies non-admin users (existing behavior)."""
+        permission = RoleBindingKesselAccessPermission()
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=False, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertFalse(result)
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=False)
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_off_tenant_does_not_call_kessel(self, mock_checker_class):
+        """With flag off, tenant checks never invoke Kessel."""
+        permission = RoleBindingKesselAccessPermission()
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=True, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        permission.has_permission(mock_request, self._make_mock_view())
+
+        mock_checker_class.assert_not_called()
+
+    # -- Flag ON: tenant checks go through Kessel --
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.FEATURE_FLAGS")
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_tenant_uses_kessel_check(self, mock_checker_class, mock_get_principal_id, mock_feature_flags):
+        """With flag on, tenant access uses Kessel CheckForUpdate."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_feature_flags.is_use_role_binding_view_permission_enabled.return_value = True
+        mock_get_principal_id.return_value = "localhost/test-user-123"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = True
+        mock_checker_class.return_value = mock_checker
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=False, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertTrue(result)
+        mock_checker.check_resource_access.assert_called_once()
+        call_kwargs = mock_checker.check_resource_access.call_args[1]
+        self.assertEqual(call_kwargs["resource_type"], "tenant")
+        self.assertEqual(call_kwargs["resource_id"], tenant_resource_id)
+        self.assertEqual(call_kwargs["relation"], "role_binding_view")
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_tenant_denied_by_kessel(self, mock_checker_class, mock_get_principal_id):
+        """With flag on, tenant access denied when Kessel returns False."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_get_principal_id.return_value = "localhost/test-user-123"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = False
+        mock_checker_class.return_value = mock_checker
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=True, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertFalse(result)
+        mock_checker.check_resource_access.assert_called_once()
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_non_admin_allowed_by_kessel(self, mock_checker_class, mock_get_principal_id):
+        """With flag on, non-admin users CAN access tenant if Kessel allows (delegation)."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_get_principal_id.return_value = "localhost/delegated-user-456"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = True
+        mock_checker_class.return_value = mock_checker
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=False, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertTrue(result)
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_tenant_denied_when_resource_id_mismatch(self, mock_checker_class):
+        """With flag on, mismatched resource_id still denied before Kessel call."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_request = self._make_mock_request(
+            admin=True, resource_id="localhost/other-org-99999", resource_type="tenant"
+        )
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertFalse(result)
+        mock_checker_class.assert_not_called()
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_tenant_denied_when_no_tenant(self, mock_checker_class):
+        """With flag on, denied when no tenant on request."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_request = self._make_mock_request(admin=True, resource_id="some-id", resource_type="tenant")
+        mock_request.tenant = None
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertFalse(result)
+        mock_checker_class.assert_not_called()
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_tenant_denied_when_no_principal_id(self, mock_checker_class, mock_get_principal_id):
+        """With flag on, denied when principal_id cannot be resolved."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_get_principal_id.return_value = None
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = self._make_mock_request(admin=True, resource_id=tenant_resource_id, resource_type="tenant")
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertFalse(result)
+        mock_checker_class.assert_not_called()
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.FEATURE_FLAGS")
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_tenant_write_uses_grant_relation(
+        self, mock_checker_class, mock_get_principal_id, mock_feature_flags
+    ):
+        """With flag on, batch_create on tenant uses role_binding_grant relation."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_feature_flags.is_use_role_binding_view_permission_enabled.return_value = True
+        mock_get_principal_id.return_value = "localhost/test-user-123"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = True
+        mock_checker_class.return_value = mock_checker
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = Mock()
+        mock_request.user.system = False
+        mock_request.user.admin = False
+        mock_request.query_params = {}
+        mock_request.data = {
+            "requests": [
+                {
+                    "resource": {"id": tenant_resource_id, "type": "tenant"},
+                    "subject": {"id": "some-group-id", "type": "group"},
+                    "role": {"id": "some-role-id"},
+                }
+            ]
+        }
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view(action="batch_create"))
+
+        self.assertTrue(result)
+        mock_checker.check_resource_access.assert_called_once()
+        call_kwargs = mock_checker.check_resource_access.call_args[1]
+        self.assertEqual(call_kwargs["relation"], "role_binding_grant")
+        self.assertEqual(call_kwargs["resource_type"], "tenant")
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.FEATURE_FLAGS")
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_put_by_subject_tenant_checks_grant_and_revoke(
+        self, mock_checker_class, mock_get_principal_id, mock_feature_flags
+    ):
+        """With flag on, PUT by_subject on tenant checks both grant and revoke."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_feature_flags.is_use_role_binding_view_permission_enabled.return_value = True
+        mock_get_principal_id.return_value = "localhost/test-user-123"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = True
+        mock_checker_class.return_value = mock_checker
+
+        tenant_resource_id = self.tenant.tenant_resource_id()
+        mock_request = Mock()
+        mock_request.method = "PUT"
+        mock_request.user.system = False
+        mock_request.user.admin = False
+        mock_request.query_params = {
+            "resource_id": tenant_resource_id,
+            "resource_type": "tenant",
+        }
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertTrue(result)
+        self.assertEqual(mock_checker.check_resource_access.call_count, 2)
+        relations_checked = [call[1]["relation"] for call in mock_checker.check_resource_access.call_args_list]
+        self.assertIn("role_binding_grant", relations_checked)
+        self.assertIn("role_binding_revoke", relations_checked)
+
+    # -- Flag ON: workspace checks are unaffected --
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_workspace_check_unchanged(self, mock_checker_class, mock_get_principal_id):
+        """With flag on, workspace checks still go through Kessel as before."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_get_principal_id.return_value = "localhost/test-user-123"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = True
+        mock_checker_class.return_value = mock_checker
+
+        mock_request = self._make_mock_request(
+            admin=False, resource_id=str(self.workspace.id), resource_type="workspace"
+        )
+
+        result = permission.has_permission(mock_request, self._make_mock_view())
+
+        self.assertTrue(result)
+        call_kwargs = mock_checker.check_resource_access.call_args[1]
+        self.assertEqual(call_kwargs["resource_type"], "workspace")
+
+    # -- Flag ON: unscoped reads (no resource params) go through Kessel on tenant --
+
+    @override_settings(KESSEL_TENANT_AUTH_ENABLED=True)
+    @patch("management.permissions.role_binding_access.get_kessel_principal_id")
+    @patch("management.permissions.role_binding_access.WorkspaceInventoryAccessChecker")
+    def test_flag_on_unscoped_list_uses_kessel(self, mock_checker_class, mock_get_principal_id):
+        """With flag on, list without resource params goes through Kessel on tenant."""
+        permission = RoleBindingKesselAccessPermission()
+        mock_get_principal_id.return_value = "localhost/test-user-123"
+
+        mock_checker = MagicMock()
+        mock_checker.check_resource_access.return_value = True
+        mock_checker_class.return_value = mock_checker
+
+        mock_request = self._make_mock_request(admin=False)
+        mock_request.tenant = self.tenant
+
+        result = permission.has_permission(mock_request, self._make_mock_view(action="list"))
+
+        self.assertTrue(result)
+        mock_checker.check_resource_access.assert_called_once()
+        call_kwargs = mock_checker.check_resource_access.call_args[1]
+        self.assertEqual(call_kwargs["resource_type"], "tenant")


### PR DESCRIPTION
## Link(s) to Jira
- https://redhat.atlassian.net/browse/RHCLOUD-46266

## Description of Intent of Change(s)

**What**: Add a `KESSEL_TENANT_AUTH_ENABLED` feature flag (default `False`) that controls whether tenant-level role binding permission checks use the Kessel Inventory API (`CheckForUpdate`) instead of the hardcoded `request.user.admin` middleware shortcut.

**Why**: Currently, only org admins can perform tenant-scoped role binding operations because the permission check is hardcoded to `request.user.admin`. This prevents delegation -- org admins cannot grant tenant-level access to other users because there is nothing in Kessel (SpiceDB) to check against. The SpiceDB schema already supports the needed permissions (`role_binding_view`, `role_binding_grant`, `role_binding_revoke`) on tenant resources via the `@add_unified_permission` macro, and the admin group membership sync already exists in `_default_group_tuple_edits()`.

**How**: When `KESSEL_TENANT_AUTH_ENABLED=True`, the tenant branch in `_check_single_resource()` falls through to the existing Kessel `check_resource_access` path (the same path workspace resources already use), instead of short-circuiting on `request.user.admin`. The tenant resource_id validation (cross-tenant protection) always runs first, regardless of flag state.

### Changes

1. **`rbac/rbac/settings.py`** -- Added `KESSEL_TENANT_AUTH_ENABLED` env-configurable setting (default `False`)
2. **`rbac/management/permissions/role_binding_access.py`** -- Restructured `_check_single_resource` tenant branch: tenant resource_id match validation runs first (always), then flag determines org-admin check (off) vs Kessel path (on). Updated `_resolve_principal_id` to resolve principal for tenant resources when flag is enabled.
3. **`tests/management/role_binding/test_role_binding_access.py`** -- 13 new tests in `RoleBindingKesselTenantAuthTests` covering both flag states

## Local Testing

V2 APIs require Kessel for auth locally, so unit tests are the verification path:

```bash
# Run just the new tests (13 tests)
pipenv run tox -e py312-fast -- tests.management.role_binding.test_role_binding_access.RoleBindingKesselTenantAuthTests

# Run the full role binding access test suite (109 tests)
pipenv run tox -e py312-fast -- tests.management.role_binding.test_role_binding_access

# Run full test suite (4293 tests)
pipenv run tox -e py312-fast
```

All 4293 tests pass. Lint passes.

## Checklist
- [ ] if API spec changes are required, is the spec updated? N/A -- no API spec changes
- [ ] are there any pre/post merge actions required? if so, document here. None -- flag defaults to False
- [x] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for? N/A
- [ ] does this require migration changes? No
- [ ] is there known, direct impact to dependent teams/components? No -- flag defaults to off

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [x] Input Validation -- tenant resource_id validation runs before flag check (cross-tenant always blocked)
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control -- flag-off preserves existing org-admin behavior; flag-on delegates to Kessel
- [x] Cryptographic Practices
- [x] Error Handling and Logging -- SEC-MON-REQ-1 compliance logging preserved
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting for tenant-level role-binding authorization through Kessel.
  * When enabled, tenant access checks use Kessel authorization and validation.
  * When disabled, existing org-admin-based tenant access behavior remains unchanged.

* **Bug Fixes**
  * Improved authorization handling for tenant-only and batch access checks.

* **Tests**
  * Added coverage for both authorization modes, including tenant and principal validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->