### PR TITLE
fix(debezium): remove empty connector-offsets annotation that breaks connector on newer Strimzi [RHCLOUD-50479]

### DIFF
--- a/deploy/debezium-connector.yml
+++ b/deploy/debezium-connector.yml
@@ -9,7 +9,6 @@ objects:
     name: ${CONNECTOR_NAME}
     annotations:
       strimzi.io/use-connector-resources: "true"
-      strimzi.io/connector-offsets: "${CONNECTOR_OFFSETS_RESET}"
     labels:
       strimzi.io/cluster: ${KAFKA_CONNECT_INSTANCE}
   spec:
@@ -86,6 +85,3 @@ parameters:
 - name: SNAPSHOT_MODE
   value: "initial"
   description: The snapshot mode for the connector
-- name: CONNECTOR_OFFSETS_RESET
-  value: ""
-  description: "Set to 'reset' to clear connector offsets via Strimzi annotation (connector must be stopped first)"


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-50479

## Problem

The perf `rbac-debezium` KafkaConnector is stuck `NotReady`:

```
type: NotReady
reason: IllegalArgumentException
message: No enum constant io.strimzi.operator.cluster.model.KafkaConnectorOffsetsAnnotation.
```

The template unconditionally renders:

```yaml
strimzi.io/connector-offsets: "${CONNECTOR_OFFSETS_RESET}"
```

with `CONNECTOR_OFFSETS_RESET` defaulting to `""`. Strimzi operators that support connector-offsets management (>= 0.43) parse this annotation into the `KafkaConnectorOffsetsAnnotation` enum (`list`/`alter`/`reset`) on **every** reconcile. An empty string is not a valid enum constant, so the operator throws `IllegalArgumentException` and aborts the reconcile **before the connector is ever created** on the Connect cluster.

No connector → no CDC from `management_outbox` → no `outbox.event.workspace` events → HBI times out waiting for RBAC workspace-creation events (`TimeoutError: No workspace creation message consumed in time`).

### Why only perf broke

Stage/prod Connect clusters run older Strimzi operators that ignore the unknown annotation (inert metadata). Perf's operator was upgraded to a version that validates it, turning a previously-harmless empty string into a hard failure. Same rendered manifest, stricter operator.

## Fix

Remove the `strimzi.io/connector-offsets` annotation and the now-unused `CONNECTOR_OFFSETS_RESET` parameter. This annotation is a **one-shot trigger** — the operator performs the offsets operation and then removes the annotation itself — so it should never be baked into a continuously-reconciled manifest (there is no "do nothing" enum value; the do-nothing state is the annotation being absent).

Reverts the template portion of `5d95de875`.

## Offset resets during DR

The capability isn't lost. When a DR restore actually needs an offset reset, do it ad-hoc (connector stopped first):

```
oc annotate kafkaconnector rbac-debezium -n <connect-ns> strimzi.io/connector-offsets=reset
```

The operator performs the reset and clears the annotation, which is the intended Strimzi workflow for trigger annotations.

## Rollout

perf and stage debezium targets track `ref: master`, so this auto-reconciles once merged: qontract re-renders the CR without the annotation, the operator removes the field it originally set, and the connector reconciles to `Ready` — restoring CDC and unblocking HBI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the connector offsets reset configuration from the deployment settings.
  * Simplified the Kafka connector configuration by removing the related metadata annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
