### PR TITLE
chore(ci): flag PRs missing a JIRA ticket with a label [RHCLOUD-50482]

### DIFF
--- a/.github/workflows/jira-ticket-check.yml
+++ b/.github/workflows/jira-ticket-check.yml
@@ -25,15 +25,34 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          NO_JIRA_LABEL: "no jira ticket"
+          # Hidden marker so we only ever post the comment once per PR.
+          COMMENT_MARKER: "<!-- jira-ticket-check -->"
         run: |
-          if printf '%s\n' "$PR_TITLE" | grep -qE '\[RHCLOUD-[0-9]+\]'; then
+          # Match any JIRA project key, e.g. [RHCLOUD-12345], [ABC-1], [HMS-42].
+          if printf '%s\n' "$PR_TITLE" | grep -qE '\[[A-Z][A-Z0-9]+-[0-9]+\]'; then
             echo "✅ JIRA ticket found in PR title"
+            # Title was fixed on an edit — clean up the label if it's still there.
+            gh pr edit "$PR_NUMBER" --remove-label "$NO_JIRA_LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          echo "❌ PR title must contain a JIRA ticket reference in the format [PROJECT-XXXXX]"
+
+          # Flag the PR with the (pre-existing) label.
+          gh pr edit "$PR_NUMBER" --add-label "$NO_JIRA_LABEL"
+
+          # Post the reminder comment only once — skip if our marker is present.
+          if gh pr view "$PR_NUMBER" --json comments \
+              --jq '.comments[].body' | grep -qF "$COMMENT_MARKER"; then
+            echo "ℹ️ Reminder comment already exists — not posting again."
           else
-            echo "❌ PR title must contain a JIRA ticket reference in the format [RHCLOUD-XXXXX]"
-            printf -v COMMENT '%s\n\n%s\n\n%s' \
+            printf -v COMMENT '%s\n%s\n\n%s\n\n%s' \
+              "$COMMENT_MARKER" \
               '❌ **Missing JIRA ticket in PR title**' \
-              'PR title must contain a JIRA ticket reference in the format `[RHCLOUD-XXXXX]`.' \
+              'PR title must contain a JIRA ticket reference in the format `[PROJECT-XXXXX]`.' \
               '**Example:** `feat: add new feature [RHCLOUD-12345]`'
             gh pr comment "$PR_NUMBER" --body "$COMMENT"
-            exit 1
           fi
+
+          exit 1

--- a/.github/workflows/jira-ticket-check.yml
+++ b/.github/workflows/jira-ticket-check.yml
@@ -33,7 +33,15 @@ jobs:
           if printf '%s\n' "$PR_TITLE" | grep -qE '\[[A-Z][A-Z0-9]+-[0-9]+\]'; then
             echo "✅ JIRA ticket found in PR title"
             # Title was fixed on an edit — clean up the label if it's still there.
-            gh pr edit "$PR_NUMBER" --remove-label "$NO_JIRA_LABEL" 2>/dev/null || true
+            # Tolerate "label not found" but let auth/API/network errors propagate.
+            if ! gh pr edit "$PR_NUMBER" --remove-label "$NO_JIRA_LABEL" 2>label_err; then
+              if grep -qi "not found" label_err; then
+                echo "ℹ️ Label not present — nothing to remove."
+              else
+                cat label_err >&2
+                exit 1
+              fi
+            fi
             exit 0
           fi
 
@@ -43,8 +51,13 @@ jobs:
           gh pr edit "$PR_NUMBER" --add-label "$NO_JIRA_LABEL"
 
           # Post the reminder comment only once — skip if our marker is present.
-          if gh pr view "$PR_NUMBER" --json comments \
-              --jq '.comments[].body' | grep -qF "$COMMENT_MARKER"; then
+          # Fetch comments first; abort if the lookup itself fails.
+          if ! COMMENTS=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body'); then
+            echo "::error::Failed to fetch PR comments — aborting to avoid a duplicate reminder."
+            exit 1
+          fi
+
+          if printf '%s\n' "$COMMENTS" | grep -qF "$COMMENT_MARKER"; then
             echo "ℹ️ Reminder comment already exists — not posting again."
           else
             printf -v COMMENT '%s\n%s\n\n%s\n\n%s' \


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-50482

## Description of Intent of Change(s)
Improves the **JIRA ticket check** GitHub Action (`.github/workflows/jira-ticket-check.yml`).

- **WHAT:** The workflow that verifies a PR title contains a JIRA ticket reference now (1) recognizes any JIRA project key rather than only `RHCLOUD`, (2) posts its reminder comment only once instead of on every title edit, and (3) applies a `no jira ticket` label when a ticket is missing (removing it once the title is corrected).
- **WHY:** The old behavior re-posted a new comment on each `edited` event, cluttering PRs, and only matched the `RHCLOUD` project, so PRs referencing other JIRA projects were incorrectly flagged. A label gives a durable, glanceable signal.
- **HOW:**
  - Generalized the title regex from `\[RHCLOUD-[0-9]+\]` to `\[[A-Z][A-Z0-9]+-[0-9]+\]`, matching keys like `[ABC-123]`, `[HMS-42]`.
  - Guarded the comment with a hidden HTML marker (`<!-- jira-ticket-check -->`); before posting, existing comments are checked for the marker so it is only ever added once per PR.
  - On the failure path, adds the pre-existing `no jira ticket` label; on the success path, removes it (self-healing when a title is fixed on a later edit).
  - Kept the failing exit code so the check still blocks merge.

## Local Testing
This is a GitHub Actions workflow, so it exercises on GitHub rather than locally:
- Open a PR with a title lacking any `[PROJECT-NNN]` reference → check fails, the `no jira ticket` label is applied, and a single reminder comment is posted.
- Edit the title again while still missing a ticket → no duplicate comment, label remains, check still fails.
- Edit the title to include e.g. `[ABC-123]` → check passes and the `no jira ticket` label is removed.
- YAML validated locally with `python3 -c "import yaml; yaml.safe_load(open(...))"`.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

_Note: no API/migration/unit-test changes apply — this is a CI workflow change. The `no jira ticket` label must already exist in the repo (it does)._

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests now support validation for any JIRA-style project key.
  - Added automatic reminders when a valid JIRA ticket is missing.
  - Duplicate reminders are prevented.

- **Bug Fixes**
  - The “no jira ticket” label is removed automatically after the title is corrected.
  - Validation now reports success or failure consistently.
  - Improved error handling for label updates and reminder checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->