### PR TITLE
[RHCLOUD-49753] [RHCLOUD-49754] V2 opt-in API

### DIFF
--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -42,6 +42,10 @@
     {
       "name": "Audit Logs",
       "description": "Operations about audit logs requests"
+    },
+    {
+      "name": "V2OptIn",
+      "description": "Operations related to opting into the V2 interface"
     }
   ],
   "paths": {
@@ -2804,6 +2808,181 @@
           }
         }
       }
+    },
+    "/tenant/opt-in/": {
+      "get": {
+        "tags": [
+          "V2OptIn"
+        ],
+        "summary": "Get whether the current tenant has opted into V2",
+        "operationId": "OptInStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptInStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax."
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions to list permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "V2OptIn"
+        ],
+        "summary": "Opt the current tenant into V2",
+        "operationId": "OptInUpdate",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "v2_opted_in": {
+                    "type": "boolean",
+                    "enum": [true]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptInStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Opt-in is not possible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptInIneligibleResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tenant/opt-in/eligibility/": {
+      "get": {
+        "tags": [
+          "V2OptIn"
+        ],
+        "summary": "Get information about whether the current tenant can be opted into V2",
+        "operationId": "OptInEligibility",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Contains information about the tenant's eligibility to opt-in to V2.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/OptInEligibleResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OptInIneligibleResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax."
+          },
+          "401": {
+            "description": "Access is unauthorized."
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error403"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -4504,6 +4683,110 @@
             }
           }
         ]
+      },
+      "OptInIneligibleGroup": {
+        "type": "object",
+        "required": [
+          "name",
+          "uuid",
+          "ineligible_system_roles"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ineligible_system_roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptInIneligibleRole"
+            }
+          }
+        }
+      },
+      "OptInIneligibleResponse": {
+        "type": "object",
+        "required": [
+          "eligible",
+          "bootstrapped",
+          "ineligible_custom_roles",
+          "ineligible_groups"
+        ],
+        "properties": {
+          "eligible": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "bootstrapped": {
+            "type" : "boolean"
+          },
+          "ineligible_custom_roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptInIneligibleRole"
+            }
+          },
+          "ineligible_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptInIneligibleGroup"
+            }
+          }
+        }
+      },
+      "OptInIneligibleRole": {
+        "type": "object",
+        "required": [
+          "name",
+          "uuid",
+          "ineligible_applications"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ineligible_applications": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "OptInEligibleResponse": {
+        "type": "object",
+        "required": [
+          "eligible"
+        ],
+        "properties": {
+          "eligible": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          }
+        }
+      },
+      "OptInStatus": {
+        "type": "object",
+        "required": [
+          "v2_opted_in"
+        ],
+        "properties": {
+          "v2_opted_in": {
+            "type": "boolean",
+            "description": "Whether the tenant has opted into RBAC V2."
+          }
+        }
       }
     }
   }

--- a/docs/source/specs/openapi.json
+++ b/docs/source/specs/openapi.json
@@ -2834,16 +2834,6 @@
           "401": {
             "description": "Unauthorized"
           },
-          "403": {
-            "description": "Insufficient permissions to list permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error403"
-                }
-              }
-            }
-          },
           "500": {
             "description": "Unexpected Error",
             "content": {
@@ -2964,7 +2954,7 @@
           "403": {
             "description": "Access is forbidden.",
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error403"
                 }
@@ -2974,7 +2964,7 @@
           "500": {
             "description": "Server error",
             "content": {
-              "application/problem+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error"
                 }

--- a/rbac/management/tenant_mapping/exceptions.py
+++ b/rbac/management/tenant_mapping/exceptions.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Exceptions for TenantMappings."""
+
+
+class TenantNotBootstrappedError(Exception):
+    """Raised when a tenant is required to have been bootstrapped but has not been."""
+
+    pass

--- a/rbac/management/tenant_mapping/model.py
+++ b/rbac/management/tenant_mapping/model.py
@@ -143,3 +143,41 @@ class TenantMapping(models.Model):
             return DefaultAccessType.ADMIN, Scope.TENANT
 
         return None
+
+
+# We unfortunately need raw SQL due to Django not having a built-in way to do locks FOR SHARE.
+_LOCK_FOR_SHARE_SQL = (  # sourcery: disable=sql-injection-risk
+    "SELECT * FROM management_tenantmapping WHERE tenant_id = %s FOR SHARE"
+)
+
+
+def try_lock_mapping_for_share(tenant: Tenant) -> Optional[TenantMapping]:
+    """Return the TenantMapping for the provided tenant locked FOR SHARE if it exists (otherwise None)."""
+    mappings = list(TenantMapping.objects.raw(_LOCK_FOR_SHARE_SQL, [tenant.id]))
+
+    if len(mappings) > 1:
+        raise AssertionError(f"Found multiple tenant mappings for tenant {tenant.org_id}?")
+
+    if len(mappings) == 0:
+        return None
+
+    return mappings[0]
+
+
+def lock_mapping_for_share(tenant: Tenant) -> TenantMapping:
+    """
+    Return the TenantMapping for the provided tenant locked FOR SHARE.
+
+    Raises TenantNotBootstrappedError if no TenantMapping exists.
+    """
+    # TODO fix circular dependency
+    from management.tenant_service.v2 import TenantNotBootstrappedError
+
+    mapping = try_lock_mapping_for_share(tenant)
+
+    if mapping is None:
+        raise TenantNotBootstrappedError(
+            f"Tenant {tenant.org_id} has no TenantMapping; writes require tenant bootstrapping."
+        )
+
+    return mapping

--- a/rbac/management/tenant_mapping/model.py
+++ b/rbac/management/tenant_mapping/model.py
@@ -24,6 +24,7 @@ from typing import Callable, ClassVar, Optional
 from django.db import models
 from django.db.models import CheckConstraint, Q
 from management.permission.scope_service import Scope
+from management.tenant_mapping.exceptions import TenantNotBootstrappedError
 from management.utils import as_uuid
 
 from api.models import Tenant
@@ -170,9 +171,6 @@ def lock_mapping_for_share(tenant: Tenant) -> TenantMapping:
 
     Raises TenantNotBootstrappedError if no TenantMapping exists.
     """
-    # TODO fix circular dependency
-    from management.tenant_service.v2 import TenantNotBootstrappedError
-
     mapping = try_lock_mapping_for_share(tenant)
 
     if mapping is None:

--- a/rbac/management/tenant_mapping/v2_activation.py
+++ b/rbac/management/tenant_mapping/v2_activation.py
@@ -42,32 +42,12 @@ import logging
 
 from django.db import transaction
 from django.utils import timezone
-from management.tenant_mapping.model import TenantMapping
+from management.tenant_mapping.model import TenantMapping, lock_mapping_for_share
 from management.tenant_service.v2 import TenantNotBootstrappedError
 
 from api.models import Tenant
 
 logger = logging.getLogger(__name__)
-
-# We unfortunately need raw SQL due to Django not having a built-in way to do locks FOR SHARE.
-_LOCK_FOR_SHARE_SQL = (  # sourcery: disable=sql-injection-risk
-    "SELECT * FROM management_tenantmapping WHERE tenant_id = %s FOR SHARE"
-)
-
-
-def _lock_mapping_for_share(tenant: Tenant) -> TenantMapping:
-    """Return the TenantMapping for the provided tenant locked FOR SHARE."""
-    mappings = list(TenantMapping.objects.raw(_LOCK_FOR_SHARE_SQL, [tenant.id]))
-
-    if len(mappings) > 1:
-        raise AssertionError(f"Found multiple tenant mappings for tenant {tenant.org_id}?")
-
-    if len(mappings) == 0:
-        raise TenantNotBootstrappedError(
-            f"Tenant {tenant.org_id} has no TenantMapping; writes require tenant bootstrapping."
-        )
-
-    return mappings[0]
 
 
 class V1WriteBlockedError(Exception):
@@ -83,7 +63,7 @@ def ensure_v2_write_activated(tenant: Tenant):
     reads). If not yet V2, escalates to an exclusive lock and writes. This minimises
     contention compared to always using FOR UPDATE.
     """
-    mapping = _lock_mapping_for_share(tenant)
+    mapping = lock_mapping_for_share(tenant)
 
     if mapping.v2_write_activated_at is not None:
         return
@@ -129,7 +109,7 @@ class TenantVersion(enum.IntEnum):
 
 def lock_tenant_version(tenant: Tenant):
     """Lock a tenant to its current version for the duration of the transaction. Returns the version of the tenant."""
-    mapping = _lock_mapping_for_share(tenant)
+    mapping = lock_mapping_for_share(tenant)
 
     if mapping.v2_write_activated_at is None:
         return TenantVersion.VERSION_1
@@ -147,7 +127,7 @@ def assert_v1_write_allowed(tenant: Tenant):
     # We could just use lock_tenant_version here, but we instead do the check directly in order to give a better error
     # message.
 
-    mapping = _lock_mapping_for_share(tenant)
+    mapping = lock_mapping_for_share(tenant)
 
     if mapping.v2_write_activated_at is not None:
         raise V1WriteBlockedError(
@@ -207,5 +187,5 @@ def lock_v2_opt_in_state(tenant: Tenant) -> bool:
     This is only meaningful to use within a database transaction. (Otherwise, if a lock is not needed,
     use is_v2_opted_in.)
     """
-    mapping = _lock_mapping_for_share(tenant)
+    mapping = lock_mapping_for_share(tenant)
     return mapping.v2_opted_in_at is not None

--- a/rbac/management/tenant_mapping/v2_eligibility.py
+++ b/rbac/management/tenant_mapping/v2_eligibility.py
@@ -209,7 +209,7 @@ def check_v2_eligibility(tenant: Tenant) -> OptInEligibleState | OptInIneligible
     """
     Determine whether the provided tenant is eligible to opt into V2.
 
-    Returns an OptInEligibleState if the tenant is eligible, or na OptInIneligibleState otherwise.
+    Returns an OptInEligibleState if the tenant is eligible, or an OptInIneligibleState otherwise.
     """
     mapping = try_lock_mapping_for_share(tenant)
 

--- a/rbac/management/tenant_mapping/v2_eligibility.py
+++ b/rbac/management/tenant_mapping/v2_eligibility.py
@@ -94,8 +94,9 @@ class OptInIneligibleState:
         if not isinstance(self.bootstrapped, bool):
             raise TypeError(f"Expected bootstrapped to be a bool, but got: {self.bootstrapped!r}")
 
-        if not isinstance(self.ineligible_groups, tuple) and all(
-            isinstance(g, OptInIneligibleGroup) for g in self.ineligible_groups
+        if not (
+            isinstance(self.ineligible_groups, tuple)
+            and all(isinstance(g, OptInIneligibleGroup) for g in self.ineligible_groups)
         ):
             raise TypeError(
                 f"Expected ineligible_groups to be a tuple of OptInIneligibleGroup, but got: "

--- a/rbac/management/tenant_mapping/v2_eligibility.py
+++ b/rbac/management/tenant_mapping/v2_eligibility.py
@@ -164,7 +164,7 @@ def _ineligible_groups_for(tenant: Tenant, ineligible_apps: frozenset[str]) -> l
     ineligible_groups = []
 
     for group in group_query.iterator(chunk_size=100):
-        ineligible_roles: list[OptInIneligibleRole] = [
+        ineligible_roles: set[OptInIneligibleRole] = {
             role_result
             for role_result in (
                 cached_ineligibility_for(role)
@@ -172,7 +172,7 @@ def _ineligible_groups_for(tenant: Tenant, ineligible_apps: frozenset[str]) -> l
                 for role in policy.ineligible_system_roles
             )
             if role_result is not None
-        ]
+        }
 
         if not ineligible_roles:
             continue

--- a/rbac/management/tenant_mapping/v2_eligibility.py
+++ b/rbac/management/tenant_mapping/v2_eligibility.py
@@ -1,0 +1,232 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Contains utilities for determining whether a tenant is eligible to opt into V2."""
+
+import dataclasses
+import functools
+from typing import Optional
+
+from django.conf import settings
+from django.db.models import Prefetch
+from management.atomic_transactions import atomic
+from management.group.model import Group
+from management.policy.model import Policy
+from management.role.model import Role
+from management.tenant_mapping.model import try_lock_mapping_for_share
+
+from api.models import Tenant
+
+
+@dataclasses.dataclass(frozen=True)
+class OptInIneligibleRole:
+    """Information on a role making a tenant ineligible for opting into V2."""
+
+    role: Role
+    ineligible_applications: frozenset[str]
+
+    def __post_init__(self):
+        """Establish invariants."""
+        if not isinstance(self.role, Role):
+            raise TypeError(f"Expected role to be a Role, but got: {self.role!r}")
+
+        if not (
+            isinstance(self.ineligible_applications, frozenset)
+            and all(isinstance(app, str) for app in self.ineligible_applications)
+        ):
+            raise TypeError(
+                f"Expected ineligible_applications to be a frozenset of str, but got: "
+                f"{self.ineligible_applications!r}"
+            )
+
+        if len(self.ineligible_applications) == 0:
+            raise ValueError("Expected ineligible_applications not to be empty")
+
+
+@dataclasses.dataclass(frozen=True)
+class OptInIneligibleGroup:
+    """Information on a group making a tenant ineligible for opting into V2."""
+
+    group: Group
+    ineligible_system_roles: tuple[OptInIneligibleRole, ...]
+
+    def __post_init__(self):
+        """Establish invariants."""
+        if not isinstance(self.group, Group):
+            raise TypeError(f"Expected group to be a Group, but got: {self.group!r}")
+
+        if not (
+            isinstance(self.ineligible_system_roles, tuple)
+            and all(isinstance(r, OptInIneligibleRole) for r in self.ineligible_system_roles)
+        ):
+            raise TypeError(
+                f"Expected ineligible_system_roles to be a tuple of OptInIneligibleRole, but got: "
+                f"{self.ineligible_system_roles!r}"
+            )
+
+        if len(self.ineligible_system_roles) == 0:
+            raise ValueError("Expected ineligible_system_roles not to be empty")
+
+
+@dataclasses.dataclass(frozen=True)
+class OptInIneligibleState:
+    """Information on why a tenant is ineligible to opt into V2."""
+
+    bootstrapped: bool
+    ineligible_groups: tuple[OptInIneligibleGroup, ...]
+    ineligible_custom_roles: tuple[OptInIneligibleRole, ...]
+
+    def __post_init__(self):
+        """Establish invariants."""
+        if not isinstance(self.bootstrapped, bool):
+            raise TypeError(f"Expected bootstrapped to be a bool, but got: {self.bootstrapped!r}")
+
+        if not isinstance(self.ineligible_groups, tuple) and all(
+            isinstance(g, OptInIneligibleGroup) for g in self.ineligible_groups
+        ):
+            raise TypeError(
+                f"Expected ineligible_groups to be a tuple of OptInIneligibleGroup, but got: "
+                f"{self.ineligible_groups!r}"
+            )
+
+        if not (
+            isinstance(self.ineligible_custom_roles, tuple)
+            and all(isinstance(r, OptInIneligibleRole) for r in self.ineligible_custom_roles)
+        ):
+            raise TypeError(
+                f"Expected ineligible_custom_roles to be a tuple of OptInIneligibleRole, but got: "
+                f"{self.ineligible_custom_roles!r}"
+            )
+
+        if self.bootstrapped and (not self.ineligible_groups) and (not self.ineligible_custom_roles):
+            raise ValueError("Found no reason for tenant to be ineligible")
+
+
+@dataclasses.dataclass(frozen=True)
+class OptInEligibleState:
+    """Indicates that a tenant is eligible to opt into V2."""
+
+    pass
+
+
+def _ineligibility_for_role(role: Role, ineligible_apps: frozenset[str]) -> Optional[OptInIneligibleRole]:
+    permission_apps = {access.permission.application for access in role.access.all()}
+    found_ineligible = permission_apps.intersection(ineligible_apps)
+
+    return (
+        OptInIneligibleRole(role=role, ineligible_applications=frozenset(found_ineligible))
+        if found_ineligible
+        else None
+    )
+
+
+def _ineligible_groups_for(tenant: Tenant, ineligible_apps: frozenset[str]) -> list[OptInIneligibleGroup]:
+    # The same system role may be assigned many times, and OptInIneligibleRole is immutable, so we want to avoid
+    # having to create a new instance every time.
+    @functools.cache
+    def cached_ineligibility_for(role: Role) -> Optional[OptInIneligibleRole]:
+        return _ineligibility_for_role(role=role, ineligible_apps=ineligible_apps)
+
+    group_query = (
+        Group.objects.filter(tenant=tenant, platform_default=False, admin_default=False, policies__roles__system=True)
+        .prefetch_related(
+            Prefetch(
+                "policies",
+                Policy.objects.prefetch_related(
+                    Prefetch(
+                        "roles",
+                        Role.objects.filter(system=True)
+                        .filter(access__permission__application__in=ineligible_apps)
+                        .prefetch_related("access", "access__permission")
+                        .distinct(),
+                        to_attr="ineligible_system_roles",
+                    )
+                ),
+            )
+        )
+        .distinct()
+    )
+
+    ineligible_groups = []
+
+    for group in group_query.iterator(chunk_size=100):
+        ineligible_roles: list[OptInIneligibleRole] = [
+            role_result
+            for role_result in (
+                cached_ineligibility_for(role)
+                for policy in group.policies.all()
+                for role in policy.ineligible_system_roles
+            )
+            if role_result is not None
+        ]
+
+        if not ineligible_roles:
+            continue
+
+        ineligible_groups.append(
+            OptInIneligibleGroup(
+                group=group,
+                ineligible_system_roles=tuple(ineligible_roles),
+            )
+        )
+
+    return ineligible_groups
+
+
+def _ineligible_custom_roles_for(tenant: Tenant, ineligible_apps: frozenset[str]) -> list[OptInIneligibleRole]:
+    role_query = (
+        Role.objects.filter(tenant=tenant, access__permission__application__in=ineligible_apps)
+        .prefetch_related("access", "access__permission")
+        .distinct()
+    )
+
+    return [
+        result
+        for result in (
+            _ineligibility_for_role(role, ineligible_apps=ineligible_apps)
+            for role in role_query.iterator(chunk_size=100)
+        )
+        if result is not None
+    ]
+
+
+@atomic
+def check_v2_eligibility(tenant: Tenant) -> OptInEligibleState | OptInIneligibleState:
+    """
+    Determine whether the provided tenant is eligible to opt into V2.
+
+    Returns an OptInEligibleState if the tenant is eligible, or na OptInIneligibleState otherwise.
+    """
+    mapping = try_lock_mapping_for_share(tenant)
+
+    # Opting in is idempotent, so a tenant that has already opted in can always do so again.
+    if mapping is not None and mapping.v2_opted_in_at is not None:
+        return OptInEligibleState()
+
+    ineligible_apps = frozenset(settings.V2_MIGRATION_APP_EXCLUDE_LIST)
+
+    bootstrapped = mapping is not None
+    ineligible_groups = _ineligible_groups_for(tenant, ineligible_apps=ineligible_apps)
+    ineligible_custom_roles = _ineligible_custom_roles_for(tenant, ineligible_apps=ineligible_apps)
+
+    if (not bootstrapped) or ineligible_groups or ineligible_custom_roles:
+        return OptInIneligibleState(
+            bootstrapped=bootstrapped,
+            ineligible_groups=tuple(ineligible_groups),
+            ineligible_custom_roles=tuple(ineligible_custom_roles),
+        )
+
+    return OptInEligibleState()

--- a/rbac/management/tenant_mapping/v2_opt_in_view.py
+++ b/rbac/management/tenant_mapping/v2_opt_in_view.py
@@ -1,0 +1,145 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Contains the API for tenants opting into V2."""
+
+from typing import Optional
+
+from management.atomic_transactions import atomic_with_retry
+from management.tenant_mapping.model import TenantMapping
+from management.tenant_mapping.v2_activation import set_v2_opt_in_state
+from management.tenant_mapping.v2_eligibility import OptInEligibleState, OptInIneligibleState, check_v2_eligibility
+from rest_framework import permissions, serializers
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from api.models import Tenant
+
+
+class _OptInPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if view.action == "status":
+            return True
+
+        return request.user.admin
+
+
+class _OptInRequestSerializer(serializers.Serializer):
+    v2_opted_in = serializers.BooleanField(required=False, allow_null=True)
+
+    def validate_v2_opted_in(self, value):
+        if value not in (None, True):
+            raise serializers.ValidationError("v2_opted_in can only be set to true")
+
+        return value
+
+
+class _OptInIneligibleRoleSerializer(serializers.Serializer):
+    uuid = serializers.UUIDField()
+    name = serializers.CharField()
+    ineligible_applications = serializers.ListSerializer(child=serializers.CharField())
+
+    def to_representation(self, instance):
+        return {
+            "uuid": str(instance.role.uuid),
+            "name": instance.role.name,
+            "ineligible_applications": list(sorted(instance.ineligible_applications)),
+        }
+
+
+class _OptInIneligibleGroupSerializer(serializers.Serializer):
+    uuid = serializers.UUIDField()
+    name = serializers.CharField()
+    ineligible_system_roles = _OptInIneligibleRoleSerializer(many=True)
+
+    def to_representation(self, instance):
+        return {
+            "uuid": str(instance.group.uuid),
+            "name": instance.group.name,
+            "ineligible_system_roles": self.fields["ineligible_system_roles"].to_representation(
+                instance.ineligible_system_roles
+            ),
+        }
+
+
+class _OptInIneligibilitySerializer(serializers.Serializer):
+    bootstrapped = serializers.BooleanField()
+    ineligible_custom_roles = _OptInIneligibleRoleSerializer(many=True)
+    ineligible_groups = _OptInIneligibleGroupSerializer(many=True)
+
+    def to_representation(self, instance):
+        result = super().to_representation(instance)
+        result["eligible"] = False
+
+        return result
+
+
+class OptInViewSet(ViewSet):
+    """API for updating a tenant's V2 opt-in state."""
+
+    permission_classes = (_OptInPermission,)
+
+    def _state_response_for(self, tenant: Tenant, headers: Optional[dict[str, str]] = None):
+        tenant_mapping = TenantMapping.objects.filter(tenant=tenant).first()
+
+        if headers is None:
+            headers = {}
+
+        # A non-bootstrapped tenant cannot be opted into V2.
+        if tenant_mapping is None:
+            return Response({"v2_opted_in": False}, headers=headers)
+
+        return Response({"v2_opted_in": tenant_mapping.v2_opted_in_at is not None}, headers=headers)
+
+    def _format_eligibility_data(self, eligibility: OptInEligibleState | OptInIneligibleState):
+        if isinstance(eligibility, OptInEligibleState):
+            return {"eligible": True}
+
+        if not isinstance(eligibility, OptInIneligibleState):
+            raise AssertionError(f"Unexpected eligibility: {eligibility!r}")
+
+        return _OptInIneligibilitySerializer(eligibility).data
+
+    def status(self, request):
+        """Get the current opt-in state of the requestor's tenant."""
+        return self._state_response_for(request.tenant, headers={"Cache-Control": "max-age=120, private"})
+
+    @atomic_with_retry(retries=5)
+    def partial_update(self, request):
+        """(Possibly) update the requestor's tenant's V2 opt-in state."""
+        serializer = _OptInRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if serializer.validated_data["v2_opted_in"] is None:
+            # We've not been asked to opt the tenant in, so we have nothing to do.
+            return self._state_response_for(request.tenant)
+
+        if serializer.validated_data["v2_opted_in"] is not True:
+            raise AssertionError("Validation should have rejected v2_opted_in being false")
+
+        result = check_v2_eligibility(request.tenant)
+
+        if not isinstance(result, OptInEligibleState):
+            return Response(self._format_eligibility_data(result), 422)
+
+        set_v2_opt_in_state(request.tenant, True)
+        return self._state_response_for(request.tenant)
+
+    @atomic_with_retry(retries=5)
+    def eligibility(self, request):
+        """Determine whether the requestor's tenant can be opted into V2."""
+        result = check_v2_eligibility(request.tenant)
+        return Response(self._format_eligibility_data(result), 200)

--- a/rbac/management/tenant_mapping/v2_opt_in_view.py
+++ b/rbac/management/tenant_mapping/v2_opt_in_view.py
@@ -41,11 +41,16 @@ class _OptInPermission(permissions.BasePermission):
 class _OptInRequestSerializer(serializers.Serializer):
     v2_opted_in = serializers.BooleanField(required=False, allow_null=True)
 
-    def validate_v2_opted_in(self, value):
-        if value not in (None, True):
-            raise serializers.ValidationError("v2_opted_in can only be set to true")
+    def to_internal_value(self, data):
+        result = super().to_internal_value(data)
 
-        return value
+        # DRF treats an absent v2_opted_in as None (since allow_null is True) then, *in contradiction with its
+        # documentation*, calls validate_v2_opted_in if defined. Since validate_v2_opted_in can't distinguish between
+        # an explicit null and an absent value, we have to this manually here.
+        if ("v2_opted_in" in data) and (result["v2_opted_in"] is not True):
+            raise serializers.ValidationError({"v2_opted_in": "v2_opted_in, if present, can only be set to true"})
+
+        return result
 
 
 class _OptInIneligibleRoleSerializer(serializers.Serializer):
@@ -124,17 +129,19 @@ class OptInViewSet(ViewSet):
         serializer = _OptInRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        if serializer.validated_data["v2_opted_in"] is None:
+        requested_state = serializer.validated_data.get("v2_opted_in")
+
+        if requested_state is None:
             # We've not been asked to opt the tenant in, so we have nothing to do.
             return self._state_response_for(request.tenant)
 
-        if serializer.validated_data["v2_opted_in"] is not True:
+        if requested_state is not True:
             raise AssertionError("Validation should have rejected v2_opted_in being false")
 
-        result = check_v2_eligibility(request.tenant)
+        eligibility_result = check_v2_eligibility(request.tenant)
 
-        if not isinstance(result, OptInEligibleState):
-            return Response(self._format_eligibility_data(result), status.HTTP_422_UNPROCESSABLE_ENTITY)
+        if not isinstance(eligibility_result, OptInEligibleState):
+            return Response(self._format_eligibility_data(eligibility_result), status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         set_v2_opt_in_state(request.tenant, True)
         return self._state_response_for(request.tenant)

--- a/rbac/management/tenant_mapping/v2_opt_in_view.py
+++ b/rbac/management/tenant_mapping/v2_opt_in_view.py
@@ -19,10 +19,11 @@
 from typing import Optional
 
 from management.atomic_transactions import atomic_with_retry
+from management.permissions import AdminAccessPermission
 from management.tenant_mapping.model import TenantMapping
 from management.tenant_mapping.v2_activation import set_v2_opt_in_state
 from management.tenant_mapping.v2_eligibility import OptInEligibleState, OptInIneligibleState, check_v2_eligibility
-from rest_framework import permissions, serializers
+from rest_framework import permissions, serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
@@ -34,7 +35,7 @@ class _OptInPermission(permissions.BasePermission):
         if view.action == "status":
             return True
 
-        return request.user.admin
+        return AdminAccessPermission().has_permission(request, view)
 
 
 class _OptInRequestSerializer(serializers.Serializer):
@@ -133,7 +134,7 @@ class OptInViewSet(ViewSet):
         result = check_v2_eligibility(request.tenant)
 
         if not isinstance(result, OptInEligibleState):
-            return Response(self._format_eligibility_data(result), 422)
+            return Response(self._format_eligibility_data(result), status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         set_v2_opt_in_state(request.tenant, True)
         return self._state_response_for(request.tenant)
@@ -142,4 +143,4 @@ class OptInViewSet(ViewSet):
     def eligibility(self, request):
         """Determine whether the requestor's tenant can be opted into V2."""
         result = check_v2_eligibility(request.tenant)
-        return Response(self._format_eligibility_data(result), 200)
+        return Response(self._format_eligibility_data(result), status.HTTP_200_OK)

--- a/rbac/management/tenant_service/v2.py
+++ b/rbac/management/tenant_service/v2.py
@@ -17,14 +17,13 @@ from management.relation_replicator.relation_replicator import (
     WorkspaceEventStream,
 )
 from management.relation_replicator.types import RelationTuple
+from management.tenant_mapping.exceptions import TenantNotBootstrappedError
 from management.tenant_mapping.model import DefaultAccessType, TenantMapping, logger
 from management.tenant_service.relations import default_role_binding_tuples
-from management.tenant_service.tenant_service import BootstrappedTenant
-from management.tenant_service.tenant_service import _ensure_principal_with_user_id_in_tenant
+from management.tenant_service.tenant_service import BootstrappedTenant, _ensure_principal_with_user_id_in_tenant
 from management.workspace.model import Workspace
 from management.workspace.utils.event import make_workspace_event
 from migration_tool.utils import create_relationship
-
 
 from api.models import Tenant, User
 
@@ -117,12 +116,6 @@ def try_lock_tenants_for_bootstrap(tenants: Iterable[Tenant]) -> dict[Tenant, Op
         )
 
     return result
-
-
-class TenantNotBootstrappedError(Exception):
-    """Raised when a tenant is required to have been bootstrapped but has not been."""
-
-    pass
 
 
 def try_lock_tenant_for_bootstrap(tenant: Tenant) -> Optional[TenantBootstrapLock]:

--- a/rbac/management/urls.py
+++ b/rbac/management/urls.py
@@ -16,6 +16,7 @@
 """Describes the urls and patterns for the management application."""
 
 from django.urls import include, path
+from management.tenant_mapping.v2_opt_in_view import OptInViewSet
 from management.views import (
     AccessView,
     AuditLogViewSet,
@@ -36,5 +37,7 @@ ROUTER.register(r"auditlogs", AuditLogViewSet)
 urlpatterns = [
     path("principals/", PrincipalView.as_view(), name="principals"),
     path("access/", AccessView.as_view(), name="access"),
+    path("tenant/opt-in/", OptInViewSet.as_view({"get": "status", "patch": "partial_update"}), name="opt-in"),
+    path("tenant/opt-in/eligibility/", OptInViewSet.as_view({"get": "eligibility"}), name="opt-in-eligibility"),
     path("", include(ROUTER.urls)),
 ]

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -26,29 +26,27 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
+import datetime
+import logging
 import os
 import ssl
+import sys
 from urllib.parse import quote as _url_quote
 
-import datetime
-import sys
-import logging
 import pytz
 import redis
-
+from app_common_python import DependencyEndpoints, KafkaTopics, LoadedConfig
 from boto3 import client as boto_client
 from corsheaders.defaults import default_headers
 from dateutil.parser import parse as parse_dt
-from app_common_python import LoadedConfig, KafkaTopics, DependencyEndpoints
 from feature_flags import FEATURE_FLAGS
+
+from . import database
+from .env import ENVIRONMENT
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 
-
-from . import database
-
-from .env import ENVIRONMENT
 
 # Sentry monitoring configuration
 # Note: Sentry is disabled unless it is explicitly turned on by setting DSN
@@ -472,7 +470,9 @@ ROLE_CREATE_ALLOW_LIST = ENVIRONMENT.get_value("ROLE_CREATE_ALLOW_LIST", default
 # Dual write migration configuration
 REPLICATION_TO_RELATION_ENABLED = ENVIRONMENT.bool("REPLICATION_TO_RELATION_ENABLED", default=False)
 EPH_ENV = ENVIRONMENT.bool("EPH_ENV", default=False)
-V2_MIGRATION_APP_EXCLUDE_LIST = ENVIRONMENT.get_value("V2_MIGRATION_APP_EXCLUDE_LIST", default="").split(",")
+V2_MIGRATION_APP_EXCLUDE_LIST = [
+    app.strip() for app in ENVIRONMENT.get_value("V2_MIGRATION_APP_EXCLUDE_LIST", default="").split(",") if app.strip()
+]
 V2_BOOTSTRAP_TENANT = ENVIRONMENT.bool("V2_BOOTSTRAP_TENANT", default=False)
 
 # Migration Setup

--- a/tests/management/tenant_mapping/test_v2_eligibility.py
+++ b/tests/management/tenant_mapping/test_v2_eligibility.py
@@ -17,9 +17,14 @@
 """Tests for V2 eligibility."""
 
 from django.test import TestCase, override_settings
-
 from management.group.model import Group
-from management.tenant_mapping.v2_eligibility import OptInIneligibleRole, OptInIneligibleState, check_v2_eligibility
+from management.tenant_mapping.v2_activation import set_v2_opt_in_state
+from management.tenant_mapping.v2_eligibility import (
+    OptInEligibleState,
+    OptInIneligibleRole,
+    OptInIneligibleState,
+    check_v2_eligibility,
+)
 from tests.management.role.test_dual_write import RbacFixture
 from tests.v2_util import bootstrap_tenant_for_v2_test
 
@@ -34,6 +39,24 @@ class V2EligibilityTestCase(TestCase):
 
         self.fixture = RbacFixture()
         self.tenant = self.fixture.new_tenant("some-org").tenant
+
+    def test_eligible(self):
+        group, _ = self.fixture.new_group("g", self.tenant, ["p1"])
+
+        system_role = self.fixture.new_system_role("system", ["app:*:*"])
+        self.fixture.add_role_to_group(system_role, group)
+
+        self.fixture.new_custom_role("eligible", self.fixture.workspace_access(["app:*:*"]), self.tenant)
+
+        self.assertIsInstance(check_v2_eligibility(self.tenant), OptInEligibleState)
+
+    def test_eligible_opted_in(self):
+        # Some tenants will have opted-in while having ineligible roles. We should still say they are eligible to opt in
+        # again, since opting in is idempotent.
+        self.fixture.new_custom_role("custom", self.fixture.workspace_access(["ineligible:*:*"]), self.tenant)
+        set_v2_opt_in_state(self.tenant, True)
+
+        self.assertIsInstance(check_v2_eligibility(self.tenant), OptInEligibleState)
 
     def test_ineligible_not_bootstrapped(self):
         new_tenant = self.fixture.new_unbootstrapped_tenant("new-org")

--- a/tests/management/tenant_mapping/test_v2_eligibility.py
+++ b/tests/management/tenant_mapping/test_v2_eligibility.py
@@ -1,0 +1,131 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Tests for V2 eligibility."""
+
+from django.test import TestCase, override_settings
+
+from management.group.model import Group
+from management.tenant_mapping.v2_eligibility import OptInIneligibleRole, OptInIneligibleState, check_v2_eligibility
+from tests.management.role.test_dual_write import RbacFixture
+from tests.v2_util import bootstrap_tenant_for_v2_test
+
+from api.models import Tenant
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+@override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["ineligible", "bad"])
+class V2EligibilityTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.fixture = RbacFixture()
+        self.tenant = self.fixture.new_tenant("some-org").tenant
+
+    def test_ineligible_not_bootstrapped(self):
+        new_tenant = self.fixture.new_unbootstrapped_tenant("new-org")
+
+        result = check_v2_eligibility(new_tenant)
+
+        self.assertIsInstance(result, OptInIneligibleState)
+        self.assertFalse(result.bootstrapped)
+        self.assertCountEqual([], result.ineligible_groups)
+        self.assertCountEqual([], result.ineligible_custom_roles)
+
+    def test_ineligible_roles(self):
+        self.fixture.new_custom_role("eligible", self.fixture.workspace_access(["app:*:*"]), self.tenant)
+
+        ineligible_a = self.fixture.new_custom_role(
+            "ineligible a", self.fixture.workspace_access(["app:*:*", "ineligible:*:*", "bad:*:*"]), self.tenant
+        )
+
+        ineligible_b = self.fixture.new_custom_role(
+            "ineligible b", self.fixture.workspace_access(["ineligible:*:*"]), self.tenant
+        )
+
+        result = check_v2_eligibility(self.tenant)
+
+        self.assertIsInstance(result, OptInIneligibleState)
+        self.assertTrue(result.bootstrapped)
+        self.assertCountEqual([], result.ineligible_groups)
+
+        self.assertCountEqual(
+            [
+                OptInIneligibleRole(role=ineligible_a, ineligible_applications=frozenset({"ineligible", "bad"})),
+                OptInIneligibleRole(role=ineligible_b, ineligible_applications=frozenset({"ineligible"})),
+            ],
+            result.ineligible_custom_roles,
+        )
+
+    def test_ineligible_groups(self):
+        eligible = self.fixture.new_system_role("eligible", ["app:*:*"])
+
+        ineligible_a = self.fixture.new_system_role("ineligible a", ["app:*:*", "ineligible:*:*", "bad:*:*"])
+        ineligible_b = self.fixture.new_system_role("ineligible b", ["ineligible:*:*"])
+
+        ineligible_custom = self.fixture.new_custom_role(
+            "custom", self.fixture.workspace_access(["ineligible:*:*"]), self.tenant
+        )
+
+        # A group with only an eligible system role.
+        group_a = self.fixture.new_group("group a", self.tenant, ["p1"])[0]
+        self.fixture.add_role_to_group(eligible, group_a)
+
+        # A group with only an eligible custom role.
+        group_b = self.fixture.new_group("group b", self.tenant, ["p1"])[0]
+        self.fixture.add_role_to_group(ineligible_custom, group_b)
+
+        # A group with a single ineligible system role.
+        group_c = self.fixture.new_group("group c", self.tenant, ["p1"])[0]
+        self.fixture.add_role_to_group(ineligible_a, group_c)
+
+        # A group with an eligible system role and two ineligible system roles.
+        group_d = self.fixture.new_group("group d", self.tenant, ["p1"])[0]
+        self.fixture.add_role_to_group(eligible, group_d)
+        self.fixture.add_role_to_group(ineligible_a, group_d)
+        self.fixture.add_role_to_group(ineligible_b, group_d)
+
+        # A group with an eligible system role, an ineligible system role, and an ineligible custom role.
+        group_e = self.fixture.new_group("group e", self.tenant, ["p1"])[0]
+        self.fixture.add_role_to_group(eligible, group_e)
+        self.fixture.add_role_to_group(ineligible_a, group_e)
+        self.fixture.add_role_to_group(ineligible_custom, group_e)
+
+        result = check_v2_eligibility(self.tenant)
+
+        self.assertIsInstance(result, OptInIneligibleState)
+        self.assertTrue(result.bootstrapped)
+        self.assertCountEqual([ineligible_custom], [r.role for r in result.ineligible_custom_roles])
+
+        self.assertCountEqual([group_c, group_d, group_e], [g.group for g in result.ineligible_groups])
+
+        def assert_roles_for(group: Group, roles: list[OptInIneligibleRole]):
+            found_entries = [g for g in result.ineligible_groups if g.group == group]
+            self.assertEqual(len(found_entries), 1)
+
+            self.assertCountEqual(roles, found_entries[0].ineligible_system_roles)
+
+        assert_roles_for(group_c, [OptInIneligibleRole(ineligible_a, frozenset({"ineligible", "bad"}))])
+
+        assert_roles_for(
+            group_d,
+            [
+                OptInIneligibleRole(ineligible_a, frozenset({"ineligible", "bad"})),
+                OptInIneligibleRole(ineligible_b, frozenset({"ineligible"})),
+            ],
+        )
+
+        assert_roles_for(group_e, [OptInIneligibleRole(ineligible_a, frozenset({"ineligible", "bad"}))])

--- a/tests/management/tenant_mapping/test_v2_opt_in_view.py
+++ b/tests/management/tenant_mapping/test_v2_opt_in_view.py
@@ -56,7 +56,7 @@ class OptInViewSetTest(IdentityRequest):
         if body is None:
             body = {"v2_opted_in": True}
 
-        return self.client.patch(self.status_url, body, **headers)
+        return self.client.patch(self.status_url, body, content_type="application/json", **headers)
 
     def _get_eligibility(self, headers: Optional[dict] = None):
         if headers is None:
@@ -180,7 +180,15 @@ class OptInViewSetTest(IdentityRequest):
         response = self._send_opt_in_request(body={"v2_opted_in": False})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("v2_opted_in can only be set to true", response.content.decode())
+        self.assertIn("v2_opted_in, if present, can only be set to true", response.content.decode())
+
+        self._assert_status(False)
+
+    def test_opt_in_null_prohibited(self):
+        response = self._send_opt_in_request(body={"v2_opted_in": None})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("v2_opted_in, if present, can only be set to true", response.content.decode())
 
         self._assert_status(False)
 

--- a/tests/management/tenant_mapping/test_v2_opt_in_view.py
+++ b/tests/management/tenant_mapping/test_v2_opt_in_view.py
@@ -20,7 +20,7 @@ from unittest.mock import ANY
 from django.test import override_settings
 from django.urls import reverse
 from management.tenant_mapping.model import TenantMapping
-from management.tenant_mapping.v2_activation import is_v2_opted_in, lock_v2_opt_in_state, set_v2_opt_in_state
+from management.tenant_mapping.v2_activation import is_v2_opted_in, set_v2_opt_in_state
 from rest_framework import status
 from rest_framework.test import APIClient
 from tests.identity_request import IdentityRequest
@@ -162,6 +162,8 @@ class OptInViewSetTest(IdentityRequest):
             [{"name": custom_role.name, "uuid": str(custom_role.uuid), "ineligible_applications": ["ineligible"]}],
         )
 
+        return response
+
     def test_opt_in_ineligible(self):
         self._assert_ineligible_response(self._send_opt_in_request, status.HTTP_422_UNPROCESSABLE_ENTITY)
         self._assert_status(False)
@@ -189,13 +191,16 @@ class OptInViewSetTest(IdentityRequest):
     def test_eligibility_eligible(self):
         response = self._get_eligibility()
         self.assertEqual(response.data, {"eligible": True})
+        self.assertNotIn("Cache-Control", response.headers)
 
     def test_eligibility_opted_in(self):
         self._opt_in_and_assert_success()
 
         response = self._get_eligibility()
         self.assertEqual(response.data, {"eligible": True})
+        self.assertNotIn("Cache-Control", response.headers)
 
     def test_eligibility_ineligible(self):
-        self._assert_ineligible_response(self._get_eligibility, status.HTTP_200_OK)
+        response = self._assert_ineligible_response(self._get_eligibility, status.HTTP_200_OK)
         self._assert_status(False)
+        self.assertNotIn("Cache-Control", response.headers)

--- a/tests/management/tenant_mapping/test_v2_opt_in_view.py
+++ b/tests/management/tenant_mapping/test_v2_opt_in_view.py
@@ -1,0 +1,201 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from typing import Optional
+from unittest.mock import ANY
+
+from django.test import override_settings
+from django.urls import reverse
+from management.tenant_mapping.model import TenantMapping
+from management.tenant_mapping.v2_activation import is_v2_opted_in, lock_v2_opt_in_state, set_v2_opt_in_state
+from rest_framework import status
+from rest_framework.test import APIClient
+from tests.identity_request import IdentityRequest
+from tests.management.role.test_dual_write import RbacFixture
+from tests.v2_util import bootstrap_tenant_for_v2_test
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+@override_settings(V2_MIGRATION_APP_EXCLUDE_LIST=["ineligible", "bad"])
+class OptInViewSetTest(IdentityRequest):
+    def setUp(self):
+        super().setUp()
+
+        self.status_url = reverse("v1_management:opt-in")
+        self.eligibility_url = reverse("v1_management:opt-in-eligibility")
+
+        self.non_admin_headers = self._create_request_context(self.customer_data, self.user_data, is_org_admin=False)[
+            "request"
+        ].META
+
+        self.client = APIClient()
+        self.fixture = RbacFixture()
+
+        bootstrap_tenant_for_v2_test(self.tenant)
+
+    def _debootstrap(self):
+        TenantMapping.objects.filter(tenant=self.tenant).delete()
+
+    def _send_opt_in_request(self, headers: Optional[dict] = None, body: Optional[dict] = None):
+        if headers is None:
+            headers = self.headers
+
+        if body is None:
+            body = {"v2_opted_in": True}
+
+        return self.client.patch(self.status_url, body, **headers)
+
+    def _get_eligibility(self, headers: Optional[dict] = None):
+        if headers is None:
+            headers = self.headers
+
+        return self.client.get(self.eligibility_url, **headers)
+
+    def _assert_status(self, opted_in: bool):
+        response = self.client.get(self.status_url, **self.non_admin_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"v2_opted_in": opted_in})
+        self.assertEqual(response.headers["Cache-Control"], "max-age=120, private")
+
+    def _opt_in_and_assert_success(self):
+        response = self._send_opt_in_request()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"v2_opted_in": True})
+
+    def test_unbootstrapped_status(self):
+        self._debootstrap()
+        self._assert_status(False)
+
+    def test_bootstrapped_initial_status(self):
+        self._assert_status(False)
+
+    def test_opted_in_status(self):
+        set_v2_opt_in_state(self.tenant, True)
+        self._assert_status(True)
+
+    def test_non_admin_opt_in_prohibited(self):
+        response = self._send_opt_in_request(headers=self.non_admin_headers)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unbootstrapped_opt_in(self):
+        self._debootstrap()
+
+        response = self._send_opt_in_request()
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(
+            response.data,
+            {"eligible": False, "bootstrapped": False, "ineligible_custom_roles": [], "ineligible_groups": []},
+        )
+
+    def test_opt_in_eligible(self):
+        group = self.fixture.new_group("a group", self.tenant, ["p1"])[0]
+        system_role = self.fixture.new_system_role("system role", ["eligible:*:*"])
+        custom_role = self.fixture.new_custom_role(
+            "custom role", self.fixture.workspace_access(["eligible:*:*"]), self.tenant
+        )
+
+        self.fixture.add_role_to_group(system_role, group)
+        self.fixture.add_role_to_group(custom_role, group)
+
+        self._opt_in_and_assert_success()
+        self.assertTrue(is_v2_opted_in(self.tenant))
+
+    def test_opt_in_idempotent(self):
+        self._opt_in_and_assert_success()
+        self._opt_in_and_assert_success()
+        self.assertTrue(is_v2_opted_in(self.tenant))
+
+    def _assert_ineligible_response(self, request_fn, status_code: int):
+        group = self.fixture.new_group("a group", self.tenant, ["p1"])[0]
+        system_role = self.fixture.new_system_role("system role", ["ineligible:*:*", "bad:*:*"])
+        custom_role = self.fixture.new_custom_role(
+            "custom role", self.fixture.workspace_access(["ineligible:*:*"]), self.tenant
+        )
+
+        self.fixture.add_role_to_group(system_role, group)
+        self.fixture.add_role_to_group(custom_role, group)
+
+        response = request_fn()
+
+        self.assertEqual(response.status_code, status_code)
+        self.assertEqual(response.data["eligible"], False)
+        self.assertEqual(response.data["bootstrapped"], True)
+
+        self.assertEqual(
+            response.data["ineligible_groups"],
+            [
+                {
+                    "name": group.name,
+                    "uuid": str(group.uuid),
+                    "ineligible_system_roles": [
+                        {
+                            "name": system_role.name,
+                            "uuid": str(system_role.uuid),
+                            "ineligible_applications": ANY,
+                        }
+                    ],
+                }
+            ],
+        )
+
+        self.assertCountEqual(
+            ["ineligible", "bad"],
+            response.data["ineligible_groups"][0]["ineligible_system_roles"][0]["ineligible_applications"],
+        )
+
+        self.assertEqual(
+            response.data["ineligible_custom_roles"],
+            [{"name": custom_role.name, "uuid": str(custom_role.uuid), "ineligible_applications": ["ineligible"]}],
+        )
+
+    def test_opt_in_ineligible(self):
+        self._assert_ineligible_response(self._send_opt_in_request, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self._assert_status(False)
+
+    def test_opt_in_empty_body(self):
+        response = self._send_opt_in_request(body={})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"v2_opted_in": False})
+
+        self._assert_status(False)
+
+    def test_opt_out_prohibited(self):
+        response = self._send_opt_in_request(body={"v2_opted_in": False})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("v2_opted_in can only be set to true", response.content.decode())
+
+        self._assert_status(False)
+
+    def test_eligibility_non_admin_prohibited(self):
+        response = self._get_eligibility(headers=self.non_admin_headers)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_eligibility_eligible(self):
+        response = self._get_eligibility()
+        self.assertEqual(response.data, {"eligible": True})
+
+    def test_eligibility_opted_in(self):
+        self._opt_in_and_assert_success()
+
+        response = self._get_eligibility()
+        self.assertEqual(response.data, {"eligible": True})
+
+    def test_eligibility_ineligible(self):
+        self._assert_ineligible_response(self._get_eligibility, status.HTTP_200_OK)
+        self._assert_status(False)


### PR DESCRIPTION
## Link(s) to Jira
* [RHCLOUD-49753](https://redhat.atlassian.net/browse/RHCLOUD-49753)
* [RHCLOUD-49754](https://redhat.atlassian.net/browse/RHCLOUD-49754)

## Description of Intent of Change(s)
Per [KSL-072](https://docs.google.com/document/d/1QW00r3gtp6VdIKW1Xah0NuwH4B1WbZLZbEi86MBG_T8/edit), add APIs to allow users to read their tenant's V2 opt-in state and to allow an org admin to opt their tenant into V2.

[RHCLOUD-49753]: https://redhat.atlassian.net/browse/RHCLOUD-49753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-49754]: https://redhat.atlassian.net/browse/RHCLOUD-49754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant V2 opt-in status and eligibility endpoints.
  * Administrators can opt eligible tenants into V2.
  * Ineligible tenants receive details about affected groups, roles, and applications.
  * Added OpenAPI documentation for the new endpoints and response schemas.

* **Bug Fixes**
  * Improved tenant mapping consistency and locking during opt-in operations.

* **Tests**
  * Added coverage for eligibility checks, authorization, successful opt-in, invalid requests, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->