### PR TITLE
[RHCLOUD-48737] Don't replicate update events for ungrouped hosts workspaces

### DIFF
--- a/rbac/internal/migrations/replicate_workspaces.py
+++ b/rbac/internal/migrations/replicate_workspaces.py
@@ -27,7 +27,9 @@ class _ReplicateConfig:
     with_update_event: bool
 
 
-_permitted_types = [Workspace.Types.DEFAULT, Workspace.Types.STANDARD, Workspace.Types.UNGROUPED_HOSTS]
+_create_types = frozenset({Workspace.Types.DEFAULT, Workspace.Types.STANDARD, Workspace.Types.UNGROUPED_HOSTS})
+_update_types = frozenset({Workspace.Types.DEFAULT, Workspace.Types.STANDARD})
+_permitted_types = _create_types.union(_update_types)
 
 
 @atomic_with_retry(retries=20)
@@ -49,16 +51,18 @@ def _do_replicate_batch(
         if workspace.type not in _permitted_types:
             raise AssertionError(f"Unexpected workspace type: {workspace.type}")
 
-        replicator.replicate_workspace(
-            make_workspace_event(workspace=workspace, event_type=ReplicationEventType.CREATE_WORKSPACE),
-            config.event_stream,
-        )
-
-        if config.with_update_event:
+        if workspace.type in _create_types:
             replicator.replicate_workspace(
-                make_workspace_event(workspace=workspace, event_type=ReplicationEventType.UPDATE_WORKSPACE),
+                make_workspace_event(workspace=workspace, event_type=ReplicationEventType.CREATE_WORKSPACE),
                 config.event_stream,
             )
+
+        if workspace.type in _update_types:
+            if config.with_update_event:
+                replicator.replicate_workspace(
+                    make_workspace_event(workspace=workspace, event_type=ReplicationEventType.UPDATE_WORKSPACE),
+                    config.event_stream,
+                )
 
     return len(workspaces)
 

--- a/tests/internal/migrations/test_replicate_workspaces.py
+++ b/tests/internal/migrations/test_replicate_workspaces.py
@@ -9,6 +9,7 @@ from internal.migrations.replicate_workspaces import (
     replicate_deleted_workspaces,
     replicate_updated_workspaces,
 )
+from internal.utils import get_or_create_ungrouped_workspace
 from management.audit_log.model import AuditLog
 from management.relation_replicator.noop_replicator import NoopReplicator
 from management.relation_replicator.relation_replicator import (
@@ -120,31 +121,36 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
 
         return replicator.workspace_events_for(stream)
 
-    def _assert_event_ids(self, events: list[WorkspaceEvent], ids: Iterable[str]):
+    def _assert_event_ids(self, events: list[WorkspaceEvent], ids: Iterable[str], create_only_ids: Iterable[str] = ()):
         ids = set(ids)
+        create_only_ids = set(create_only_ids)
+
+        self.assertTrue(create_only_ids.issubset(ids))
 
         self.assertCountEqual(
             [
-                (type, id)
-                for id in ids
-                for type in [ReplicationEventType.CREATE_WORKSPACE, ReplicationEventType.UPDATE_WORKSPACE]
+                *((ReplicationEventType.CREATE_WORKSPACE, id) for id in ids),
+                *((ReplicationEventType.UPDATE_WORKSPACE, id) for id in (ids - create_only_ids)),
             ],
             [(event.event_type, event.workspace["id"]) for event in events],
         )
 
         # We also need to check that each create event precedes the corresponding update event.
         ids_created: set[str] = set()
+        ids_updated: set[str] = set()
 
         for event in events:
             if event.event_type == ReplicationEventType.CREATE_WORKSPACE:
                 ids_created.add(event.workspace["id"])
             elif event.event_type == ReplicationEventType.UPDATE_WORKSPACE:
                 self.assertIn(event.workspace["id"], ids_created)
+                ids_updated.add(event.workspace["id"])
             else:
                 self.fail(f"Unexpected event type: {event.event_type}")
 
-        # Final paranoid check
+        # Final paranoid check.
         self.assertEqual(ids_created, ids)
+        self.assertEqual(ids_updated, ids - create_only_ids)
 
     def test_replication(self):
         events = self._do_replicate(
@@ -189,6 +195,16 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         )
 
         self._assert_event_ids(events, [str(self.default_workspace.id), str(self.workspace.id)])
+
+    def test_ungrouped_hosts(self):
+        ungrouped_ws = get_or_create_ungrouped_workspace(self.tenant)
+
+        events = self._do_replicate(
+            stream=WorkspaceEventStream.STANDARD,
+            since=ungrouped_ws.modified,
+        )
+
+        self._assert_event_ids(events, [str(ungrouped_ws.id)], create_only_ids=[str(ungrouped_ws.id)])
 
 
 @override_settings(ATOMIC_RETRY_DISABLED=True)

--- a/tests/internal/migrations/test_replicate_workspaces.py
+++ b/tests/internal/migrations/test_replicate_workspaces.py
@@ -106,9 +106,9 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         self.default_workspace = Workspace.objects.default(tenant=self.tenant)
         self.workspace = WorkspaceService(NoopReplicator()).create({"name": "a workspace"}, request_tenant=self.tenant)
 
-        self.workspace.created = "2026-06-25T00:00:00Z"
-        self.workspace.modified = "2026-06-25T00:00:00Z"
-        self.workspace.save()
+        Workspace.objects.filter(pk=self.workspace.id).update(
+            created="2026-06-25T00:00:00Z", modified="2026-06-25T00:00:00Z"
+        )
 
     def _do_replicate(self, stream: WorkspaceEventStream, **kwargs) -> list[WorkspaceEvent]:
         replicator = WorkspaceCacheReplicator(NoopReplicator())
@@ -180,8 +180,7 @@ class ReplicateUpdatedWorkspacesTest(TestCase):
         self._assert_event_ids(events, [str(self.workspace.id)])
 
     def test_include_modified_default_workspace(self):
-        self.default_workspace.modified = "2026-06-25T00:00:00Z"
-        self.default_workspace.save()
+        Workspace.objects.filter(pk=self.default_workspace.pk).update(modified="2026-06-25T00:00:00Z")
 
         events = self._do_replicate(
             stream=WorkspaceEventStream.STANDARD,


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-48737](https://redhat.atlassian.net/browse/RHCLOUD-48737)

## Description of Intent of Change(s)
HBI doesn't allow updating an ungrouped hosts workspace, so we should only replicate a creation event during the rereplication job.

This was a problem during the runs to fix the linked issue, but it seems like HBI just ignored the invalid events, so we shouldn't have to re-run anything (though it still triggered some alerting).

[RHCLOUD-48737]: https://redhat.atlassian.net/browse/RHCLOUD-48737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace replication support for create-only events.
  * Ungrouped-host workspaces now receive creation events without update events.
  * Default and standard workspaces continue to receive update events when enabled.

* **Bug Fixes**
  * Improved event handling based on workspace type to prevent inappropriate replication updates.
  * Ensured workspace replication events are emitted only for supported workspace types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->