### PR TITLE
fix: Unleash bug due to version for Kafka migration testing [RHCLOUD-42232]

### DIFF
--- a/rbac/feature_flags.py
+++ b/rbac/feature_flags.py
@@ -272,10 +272,7 @@ class FeatureFlags:
 
         # Flag is enabled -> check for variant to determine mode
         try:
-            variant = self.client.get_variant(
-                self.TOGGLE_USE_KAFKA_CLEANUP,
-                fallback_variant={"name": "umb_only", "enabled": False},
-            )
+            variant = self.client.get_variant(self.TOGGLE_USE_KAFKA_CLEANUP)
 
             mode = variant.get("name", "umb_only")
 


### PR DESCRIPTION
…pported get_variant() kwarg

[RHCLOUD-42232](https://redhat.atlassian.net/browse/RHCLOUD-42232)

## Description of Intent of Change(s)
FeatureFlags.get_principal_cleanup_mode() passed a fallback_variant keyword argument to UnleashClient.get_variant(). That argument is not supported by the installed UnleashClient (6.8.0), so every call raised TypeError and was swallowed by the surrounding try/except, forcing the mode to umb_only on every invocation.

The practical effect: Kafka principal cleanup could never activate. Even with the Unleash flag rbac.principal-cleanup.use-kafka.enabled turned on and a variant set to kafka_shadow (or kafka_validation / kafka_active), the worker stayed pinned to umb_only.

### Root cause

UnleashClient.get_variant() got an unexpected keyword argument 'fallback_variant', falling back to umb_only
UnleashClient 6.x's get_variant() signature is get_variant(feature_name, context=None) — there is no fallback_variant parameter.

## Local Testing
Ran local unit tests for feature flags and all pass

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


[RHCLOUD-42232]: https://redhat.atlassian.net/browse/RHCLOUD-42232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated internal feature-flag handling for principal cleanup mode.
  - Existing behavior for missing or unrecognized flag variants remains unchanged.
  - No user-visible functionality or experience changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->