### PR TITLE
fix:  principal cleanup Kafka consumer fails to start with KafkaConfigurationError: Unrecognized configs: {'retries'} [RHCLOUD-42232]

### DIFF
--- a/rbac/core/kafka.py
+++ b/rbac/core/kafka.py
@@ -25,6 +25,26 @@ from kafka.errors import KafkaError
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
+# Producer-only client configs that KafkaConsumer rejects. settings.KAFKA_AUTH is shared
+# between producers and consumers, so these must be filtered out before building a consumer
+# to avoid KafkaConfigurationError (e.g. "Unrecognized configs: {'retries'}").
+PRODUCER_ONLY_CONFIGS = frozenset(
+    {
+        "retries",
+        "max_in_flight_requests_per_connection",
+        "acks",
+        "enable_idempotence",
+        "transactional_id",
+        "transaction_timeout_ms",
+        "compression_type",
+        "batch_size",
+        "linger_ms",
+        "buffer_memory",
+        "max_block_ms",
+        "delivery_timeout_ms",
+    }
+)
+
 
 class FakeKafkaProducer:
     """Fake kafka producer to enable local development without kafka server."""

--- a/rbac/core/kafka_consumer.py
+++ b/rbac/core/kafka_consumer.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import grpc
+from core.kafka import PRODUCER_ONLY_CONFIGS
 from django.conf import settings
 from django.db import OperationalError, connection, transaction
 from google.protobuf import json_format
@@ -854,24 +855,9 @@ class RBACKafkaConsumer:
         try:
             if kafka_auth:
                 # Filter out producer-specific configurations that are not valid for consumers
-                # Producer-only configs: retries, max_in_flight_requests_per_connection, acks, etc.
-                producer_only_configs = {
-                    "retries",
-                    "max_in_flight_requests_per_connection",
-                    "acks",
-                    "enable_idempotence",
-                    "transactional_id",
-                    "transaction_timeout_ms",
-                    "compression_type",
-                    "batch_size",
-                    "linger_ms",
-                    "buffer_memory",
-                    "max_block_ms",
-                    "delivery_timeout_ms",
-                }
-                consumer_auth = {k: v for k, v in kafka_auth.items() if k not in producer_only_configs}
+                consumer_auth = {k: v for k, v in kafka_auth.items() if k not in PRODUCER_ONLY_CONFIGS}
                 # Log if any producer-specific configs were filtered out
-                filtered_configs = set(kafka_auth.keys()) & producer_only_configs
+                filtered_configs = set(kafka_auth.keys()) & PRODUCER_ONLY_CONFIGS
                 if filtered_configs:
                     logger.info(f"Filtered out producer-specific configs for consumer: {filtered_configs}")
                 consumer = KafkaConsumer(

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -26,7 +26,7 @@ from typing import NamedTuple, Optional
 from xml.parsers.expat import ExpatError
 
 import xmltodict
-from core.kafka import RBACProducer
+from core.kafka import PRODUCER_ONLY_CONFIGS, RBACProducer
 from django.conf import settings
 from django.db import connection, transaction
 from kafka import KafkaConsumer
@@ -685,25 +685,10 @@ def process_principal_events_from_kafka(
     # Add authentication if configured
     kafka_auth = getattr(settings, "KAFKA_AUTH", None)
     if kafka_auth:
-        # Filter out producer-specific configs that KafkaConsumer rejects.
         # settings.KAFKA_AUTH is shared with the DLQ producer and includes producer-only
-        # options (e.g. "retries"), which raise KafkaConfigurationError on a consumer.
-        producer_only_configs = {
-            "retries",
-            "max_in_flight_requests_per_connection",
-            "acks",
-            "enable_idempotence",
-            "transactional_id",
-            "transaction_timeout_ms",
-            "compression_type",
-            "batch_size",
-            "linger_ms",
-            "buffer_memory",
-            "max_block_ms",
-            "delivery_timeout_ms",
-        }
-        consumer_auth = {k: v for k, v in kafka_auth.items() if k not in producer_only_configs}
-        filtered_configs = set(kafka_auth.keys()) & producer_only_configs
+        # options (e.g. "retries") that KafkaConsumer rejects; filter them out here.
+        consumer_auth = {k: v for k, v in kafka_auth.items() if k not in PRODUCER_ONLY_CONFIGS}
+        filtered_configs = set(kafka_auth.keys()) & PRODUCER_ONLY_CONFIGS
         if filtered_configs:
             logger.info(
                 "process_principal_events_from_kafka: Filtered producer-only configs for consumer: %s",

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -685,7 +685,31 @@ def process_principal_events_from_kafka(
     # Add authentication if configured
     kafka_auth = getattr(settings, "KAFKA_AUTH", None)
     if kafka_auth:
-        kafka_config.update(kafka_auth)
+        # Filter out producer-specific configs that KafkaConsumer rejects.
+        # settings.KAFKA_AUTH is shared with the DLQ producer and includes producer-only
+        # options (e.g. "retries"), which raise KafkaConfigurationError on a consumer.
+        producer_only_configs = {
+            "retries",
+            "max_in_flight_requests_per_connection",
+            "acks",
+            "enable_idempotence",
+            "transactional_id",
+            "transaction_timeout_ms",
+            "compression_type",
+            "batch_size",
+            "linger_ms",
+            "buffer_memory",
+            "max_block_ms",
+            "delivery_timeout_ms",
+        }
+        consumer_auth = {k: v for k, v in kafka_auth.items() if k not in producer_only_configs}
+        filtered_configs = set(kafka_auth.keys()) & producer_only_configs
+        if filtered_configs:
+            logger.info(
+                "process_principal_events_from_kafka: Filtered producer-only configs for consumer: %s",
+                filtered_configs,
+            )
+        kafka_config.update(consumer_auth)
 
     # Initialize consumer to None to avoid UnboundLocalError in finally block
     consumer = None


### PR DESCRIPTION
…urationError: Unrecognized configs: {'retries'}

## Link(s) to Jira
- [RHCLOUD-42232](https://redhat.atlassian.net/browse/RHCLOUD-42232)

## Description of Intent of Change(s)
The Kafka-based principal cleanup consumer could not be constructed. Every run failed at consumer creation with:

process_principal_events_from_kafka: Kafka error: KafkaConfigurationError: Unrecognized configs: {'retries'}

Because the consumer never started, zero messages were consumed — in shadow mode this meant the Kafka dry-run validated nothing (though UMB continued to write to the DB normally, since the dispatcher isolates the two backends).

### Root cause

settings.KAFKA_AUTH is a shared config dict used by both the DLQ producer and the cleanup consumer. It includes the producer-only option "retries": 5 (settings.py). In process_principal_events_from_kafka, that dict was merged directly into the consumer config and passed to KafkaConsumer(...):

kafka_config.update(kafka_auth)   # includes "retries"
...
consumer = KafkaConsumer(topic, **kafka_config)   # rejects "retries"

kafka-python's KafkaConsumer does not accept retries (it's a KafkaProducer setting), so construction raised KafkaConfigurationError. This is unrelated to topic configuration — the error occurs during client construction, before any connection or subscription.

## Local Testing
All unit tests pass

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


[RHCLOUD-42232]: https://redhat.atlassian.net/browse/RHCLOUD-42232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ