### PR TITLE
feat: add It managed Kafka connection configuration [RHCLOUD-42232]

### DIFF
--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -276,10 +276,6 @@ objects:
             value: ${KAFKA_PRINCIPAL_CLEANUP_TOPIC}
           - name: KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC
             value: ${KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC}
-          # IT-managed Kafka cluster (AWS MSK) that hosts the principal-cleanup topics.
-          # Delivered as flat keys on the rbac-secret Secret (same vault-secret -> secretKeyRef
-          # pattern as django-secret-key / principal-proxy-*). optional: true so pods still start
-          # before the secret is populated (settings.py also defaults these empty and no-ops).
           - name: IT_KAFKA_BOOTSTRAP_SERVERS
             valueFrom:
               secretKeyRef:

--- a/deploy/rbac-clowdapp.yml
+++ b/deploy/rbac-clowdapp.yml
@@ -276,6 +276,28 @@ objects:
             value: ${KAFKA_PRINCIPAL_CLEANUP_TOPIC}
           - name: KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC
             value: ${KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC}
+          # IT-managed Kafka cluster (AWS MSK) that hosts the principal-cleanup topics.
+          # Delivered as flat keys on the rbac-secret Secret (same vault-secret -> secretKeyRef
+          # pattern as django-secret-key / principal-proxy-*). optional: true so pods still start
+          # before the secret is populated (settings.py also defaults these empty and no-ops).
+          - name: IT_KAFKA_BOOTSTRAP_SERVERS
+            valueFrom:
+              secretKeyRef:
+                key: kafka-it-bootstrap-servers
+                name: rbac-secret
+                optional: true
+          - name: IT_KAFKA_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: kafka-it-username
+                name: rbac-secret
+                optional: true
+          - name: IT_KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: kafka-it-password
+                name: rbac-secret
+                optional: true
           - name: V2_MIGRATION_APP_EXCLUDE_LIST
             value: ${V2_MIGRATION_APP_EXCLUDE_LIST}
           - name: V2_STRICT_ACCESS_CHECK_FLAG_APPLICATION_NAMES

--- a/docs/source/specs/typespec/package-lock.json
+++ b/docs/source/specs/typespec/package-lock.json
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/rbac/core/kafka.py
+++ b/rbac/core/kafka.py
@@ -46,6 +46,23 @@ PRODUCER_ONLY_CONFIGS = frozenset(
 )
 
 
+def get_cluster_config(profile, *, for_consumer=False):
+    """Return (servers, auth) for a named Kafka cluster profile from settings.KAFKA_CLUSTERS.
+
+    Used by IT-managed Kafka paths (e.g. principal cleanup) to select a cluster other than the
+    default Clowder one. Unknown or unconfigured profiles return ([], {}) so callers safely no-op
+    instead of falling back to a different cluster. When ``for_consumer`` is set, producer-only
+    client configs (see PRODUCER_ONLY_CONFIGS) are stripped so the dict can be passed to a
+    KafkaConsumer without raising KafkaConfigurationError.
+    """
+    cluster = settings.KAFKA_CLUSTERS.get(profile, {})
+    servers = list(cluster.get("servers") or [])
+    auth = dict(cluster.get("auth") or {})
+    if for_consumer:
+        auth = {key: value for key, value in auth.items() if key not in PRODUCER_ONLY_CONFIGS}
+    return servers, auth
+
+
 class FakeKafkaProducer:
     """Fake kafka producer to enable local development without kafka server."""
 
@@ -57,6 +74,16 @@ class FakeKafkaProducer:
 class RBACProducer:
     """Kafka message producer to emit events to notification service."""
 
+    def __init__(self, cluster="clowder"):
+        """Select the Kafka cluster this producer targets.
+
+        Defaults to "clowder", which preserves the existing behavior of reading
+        settings.KAFKA_AUTH/KAFKA_SERVERS directly; existing callers pass no argument and are
+        unaffected. Any other profile name is resolved through settings.KAFKA_CLUSTERS via
+        get_cluster_config() (e.g. cluster="it_managed" for the principal-cleanup DLQ).
+        """
+        self._cluster = cluster
+
     def get_producer(self):
         """Init method to return fake kafka when flag is set to false."""
         if not hasattr(self, "producer"):
@@ -66,21 +93,29 @@ class RBACProducer:
                 self.producer = FakeKafkaProducer()
                 logger.info("Fake Kafka producer initialized in development mode")
             else:
+                # Default "clowder" keeps reading settings.KAFKA_AUTH/KAFKA_SERVERS directly so the
+                # existing Clowder producers are byte-for-byte unchanged; other profiles resolve
+                # through the cluster registry.
+                if self._cluster == "clowder":
+                    kafka_auth = settings.KAFKA_AUTH
+                    kafka_servers = settings.KAFKA_SERVERS
+                else:
+                    kafka_servers, kafka_auth = get_cluster_config(self._cluster)
                 while retries <= max_retries:
                     try:
-                        if settings.KAFKA_AUTH:
+                        if kafka_auth:
                             self.producer = KafkaProducer(
-                                **settings.KAFKA_AUTH,
+                                **kafka_auth,
                                 enable_idempotence=True,  # Deduplicate producer retries (v3 default)
                                 acks="all",  # Wait for all in-sync replicas (v3 default)
                             )
                             logger.info("Kafka producer initialized successfully")
                             return self.producer
-                        elif not settings.KAFKA_SERVERS:
+                        elif not kafka_servers:
                             raise AttributeError("Empty servers list")
                         else:
                             self.producer = KafkaProducer(
-                                bootstrap_servers=settings.KAFKA_SERVERS,
+                                bootstrap_servers=kafka_servers,
                                 enable_idempotence=True,  # Deduplicate producer retries (v3 default)
                                 acks="all",  # Wait for all in-sync replicas (v3 default)
                             )

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -674,9 +674,7 @@ def process_principal_events_from_kafka(
     # must use distinct consumer groups to avoid message loss and offset conflicts
     env_name = getattr(settings, "ENV_NAME", "stage")
 
-    # The principal-cleanup topics live on the IT-managed Kafka cluster (not the Clowder cluster that
-    # backs the rest of RBAC's Kafka usage). Resolve that cluster's connection settings by profile;
-    # get_cluster_config already strips producer-only configs for the consumer.
+   
     it_kafka_servers, consumer_auth = get_cluster_config("it_managed", for_consumer=True)
     if not it_kafka_servers or not consumer_auth:
         # No IT-managed credentials wired yet (or missing) -> safely no-op instead of falling back to

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -26,7 +26,7 @@ from typing import NamedTuple, Optional
 from xml.parsers.expat import ExpatError
 
 import xmltodict
-from core.kafka import PRODUCER_ONLY_CONFIGS, RBACProducer
+from core.kafka import RBACProducer, get_cluster_config
 from django.conf import settings
 from django.db import connection, transaction
 from kafka import KafkaConsumer
@@ -673,38 +673,41 @@ def process_principal_events_from_kafka(
     # In multi-env setups (staging, ephemeral, CI) that share a Kafka cluster, environments
     # must use distinct consumer groups to avoid message loss and offset conflicts
     env_name = getattr(settings, "ENV_NAME", "stage")
+
+    # The principal-cleanup topics live on the IT-managed Kafka cluster (not the Clowder cluster that
+    # backs the rest of RBAC's Kafka usage). Resolve that cluster's connection settings by profile;
+    # get_cluster_config already strips producer-only configs for the consumer.
+    it_kafka_servers, consumer_auth = get_cluster_config("it_managed", for_consumer=True)
+    if not it_kafka_servers or not consumer_auth:
+        # No IT-managed credentials wired yet (or missing) -> safely no-op instead of falling back to
+        # the Clowder cluster, which does not host the principal-cleanup topics.
+        logger.warning(
+            "process_principal_events_from_kafka: IT-managed Kafka cluster is not configured "
+            "(missing bootstrap servers or credentials). Skipping Kafka consume for topic '%s'.",
+            topic,
+        )
+        return
+
     kafka_config = {
-        "bootstrap_servers": settings.KAFKA_SERVERS,
+        "bootstrap_servers": it_kafka_servers,
         "group_id": f"{settings.SA_NAME}-{env_name}-principal-cleanup",
         "auto_offset_reset": "earliest",
         "enable_auto_commit": False,  # Manual commit for at-least-once semantics
         # No value_deserializer - leave as bytes to handle tombstones and UTF-8 errors in process_kafka_message
         "consumer_timeout_ms": 15000,  # 15 second timeout per run, matches UMB behavior
     }
-
-    # Add authentication if configured
-    kafka_auth = getattr(settings, "KAFKA_AUTH", None)
-    if kafka_auth:
-        # settings.KAFKA_AUTH is shared with the DLQ producer and includes producer-only
-        # options (e.g. "retries") that KafkaConsumer rejects; filter them out here.
-        consumer_auth = {k: v for k, v in kafka_auth.items() if k not in PRODUCER_ONLY_CONFIGS}
-        filtered_configs = set(kafka_auth.keys()) & PRODUCER_ONLY_CONFIGS
-        if filtered_configs:
-            logger.info(
-                "process_principal_events_from_kafka: Filtered producer-only configs for consumer: %s",
-                filtered_configs,
-            )
-        kafka_config.update(consumer_auth)
+    kafka_config.update(consumer_auth)
 
     # Initialize consumer to None to avoid UnboundLocalError in finally block
     consumer = None
 
-    # Initialize DLQ producer if DLQ topic is configured
+    # Initialize DLQ producer if DLQ topic is configured. The DLQ topic is also on the IT-managed
+    # cluster, so the producer must target that profile (not the default Clowder one).
     dlq_topic = getattr(settings, "KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC", None)
     dlq_producer = None
     if dlq_topic:
         try:
-            dlq_producer = RBACProducer()
+            dlq_producer = RBACProducer(cluster="it_managed")
             logger.info("process_principal_events_from_kafka: DLQ producer initialized for topic: %s", dlq_topic)
         except Exception as e:
             logger.warning(

--- a/rbac/management/principal/cleaner.py
+++ b/rbac/management/principal/cleaner.py
@@ -674,7 +674,6 @@ def process_principal_events_from_kafka(
     # must use distinct consumer groups to avoid message loss and offset conflicts
     env_name = getattr(settings, "ENV_NAME", "stage")
 
-   
     it_kafka_servers, consumer_auth = get_cluster_config("it_managed", for_consumer=True)
     if not it_kafka_servers or not consumer_auth:
         # No IT-managed credentials wired yet (or missing) -> safely no-op instead of falling back to

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -608,6 +608,42 @@ if KAFKA_ENABLED:
     if clowder_principal_cleanup_dlq_topic:
         KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC = clowder_principal_cleanup_dlq_topic.name
 
+# IT-Managed Kafka cluster (AWS MSK).
+#
+# A company-wide UMB -> Kafka shift is moving certain topics (starting with the principal-cleanup
+# canonical.user topics) onto a separate, IT-managed cluster that is NOT provisioned through Clowder.
+# Its credentials are delivered as flat keys on the rbac-secret Secret and surfaced as the env vars
+# below. This config is intentionally independent from the Clowder KAFKA_AUTH/KAFKA_SERVERS above and
+# is empty by default, so any consumer/producer that selects it safely no-ops until the secret lands
+# (and never falls back to the Clowder cluster).
+IT_KAFKA_BOOTSTRAP_SERVERS = ENVIRONMENT.get_value("IT_KAFKA_BOOTSTRAP_SERVERS", default="")
+IT_KAFKA_USERNAME = ENVIRONMENT.get_value("IT_KAFKA_USERNAME", default="")
+IT_KAFKA_PASSWORD = ENVIRONMENT.get_value("IT_KAFKA_PASSWORD", default="")
+IT_KAFKA_SASL_MECHANISM = ENVIRONMENT.get_value("IT_KAFKA_SASL_MECHANISM", default="SCRAM-SHA-512")
+IT_KAFKA_SECURITY_PROTOCOL = ENVIRONMENT.get_value("IT_KAFKA_SECURITY_PROTOCOL", default="SASL_SSL")
+
+IT_KAFKA_SERVERS = [server.strip() for server in IT_KAFKA_BOOTSTRAP_SERVERS.split(",") if server.strip()]
+IT_KAFKA_AUTH = {}
+if IT_KAFKA_SERVERS and IT_KAFKA_USERNAME and IT_KAFKA_PASSWORD:
+    IT_KAFKA_AUTH = {
+        "bootstrap_servers": IT_KAFKA_SERVERS,
+        "sasl_plain_username": IT_KAFKA_USERNAME,
+        "sasl_plain_password": IT_KAFKA_PASSWORD,
+        "sasl_mechanism": IT_KAFKA_SASL_MECHANISM.upper(),
+        "security_protocol": IT_KAFKA_SECURITY_PROTOCOL.upper(),
+        "retries": 5,  # producer-only; PRODUCER_ONLY_CONFIGS strips it for consumers
+    }
+    # No ssl_cafile: the IT-managed MSK cluster uses a public/system CA. If stage logs ever show a
+    # TLS/cert-verification failure, add IT_KAFKA_CA handling here.
+
+# Named Kafka cluster profiles. New IT-managed paths select a cluster by name via
+# core.kafka.get_cluster_config(). The existing Clowder paths are intentionally NOT migrated in this
+# change: they keep reading KAFKA_AUTH/KAFKA_SERVERS directly and never route through this registry.
+# A "clowder" profile will be added by the follow-up MR that actually migrates those call sites.
+KAFKA_CLUSTERS = {
+    "it_managed": {"servers": IT_KAFKA_SERVERS, "auth": IT_KAFKA_AUTH},
+}
+
 # BOP TLS settings
 if ENVIRONMENT.bool("CLOWDER_ENABLED", default=False) and ENVIRONMENT.bool("USE_CLOWDER_CA_FOR_BOP", default=False):
     BOP_CLIENT_CERT_PATH = LoadedConfig.tlsCAPath

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -608,14 +608,7 @@ if KAFKA_ENABLED:
     if clowder_principal_cleanup_dlq_topic:
         KAFKA_PRINCIPAL_CLEANUP_DLQ_TOPIC = clowder_principal_cleanup_dlq_topic.name
 
-# IT-Managed Kafka cluster (AWS MSK).
-#
-# A company-wide UMB -> Kafka shift is moving certain topics (starting with the principal-cleanup
-# canonical.user topics) onto a separate, IT-managed cluster that is NOT provisioned through Clowder.
-# Its credentials are delivered as flat keys on the rbac-secret Secret and surfaced as the env vars
-# below. This config is intentionally independent from the Clowder KAFKA_AUTH/KAFKA_SERVERS above and
-# is empty by default, so any consumer/producer that selects it safely no-ops until the secret lands
-# (and never falls back to the Clowder cluster).
+
 IT_KAFKA_BOOTSTRAP_SERVERS = ENVIRONMENT.get_value("IT_KAFKA_BOOTSTRAP_SERVERS", default="")
 IT_KAFKA_USERNAME = ENVIRONMENT.get_value("IT_KAFKA_USERNAME", default="")
 IT_KAFKA_PASSWORD = ENVIRONMENT.get_value("IT_KAFKA_PASSWORD", default="")

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -626,7 +626,7 @@ if IT_KAFKA_SERVERS and IT_KAFKA_USERNAME and IT_KAFKA_PASSWORD:
         "security_protocol": IT_KAFKA_SECURITY_PROTOCOL.upper(),
         "retries": 5,  # producer-only; PRODUCER_ONLY_CONFIGS strips it for consumers
     }
-   
+
 KAFKA_CLUSTERS = {
     "it_managed": {"servers": IT_KAFKA_SERVERS, "auth": IT_KAFKA_AUTH},
 }

--- a/rbac/rbac/settings.py
+++ b/rbac/rbac/settings.py
@@ -626,13 +626,7 @@ if IT_KAFKA_SERVERS and IT_KAFKA_USERNAME and IT_KAFKA_PASSWORD:
         "security_protocol": IT_KAFKA_SECURITY_PROTOCOL.upper(),
         "retries": 5,  # producer-only; PRODUCER_ONLY_CONFIGS strips it for consumers
     }
-    # No ssl_cafile: the IT-managed MSK cluster uses a public/system CA. If stage logs ever show a
-    # TLS/cert-verification failure, add IT_KAFKA_CA handling here.
-
-# Named Kafka cluster profiles. New IT-managed paths select a cluster by name via
-# core.kafka.get_cluster_config(). The existing Clowder paths are intentionally NOT migrated in this
-# change: they keep reading KAFKA_AUTH/KAFKA_SERVERS directly and never route through this registry.
-# A "clowder" profile will be added by the follow-up MR that actually migrates those call sites.
+   
 KAFKA_CLUSTERS = {
     "it_managed": {"servers": IT_KAFKA_SERVERS, "auth": IT_KAFKA_AUTH},
 }

--- a/tests/core/test_kafka.py
+++ b/tests/core/test_kafka.py
@@ -102,22 +102,26 @@ class GetClusterConfigTests(TestCase):
     """Tests for the named cluster-profile helper."""
 
     def test_returns_servers_and_auth_for_known_profile(self):
+        """A known profile returns its configured servers and auth."""
         servers, auth = get_cluster_config("it_managed")
         self.assertEqual(servers, ["it-broker:9096"])
         self.assertEqual(auth["sasl_plain_username"], "it-user")
         self.assertEqual(auth["security_protocol"], "SASL_SSL")
 
     def test_strips_producer_only_configs_for_consumer(self):
+        """for_consumer=True strips producer-only configs but keeps other auth."""
         _, auth = get_cluster_config("it_managed", for_consumer=True)
         self.assertNotIn("retries", auth)
         # Non-producer-only auth is preserved.
         self.assertEqual(auth["sasl_mechanism"], "SCRAM-SHA-512")
 
     def test_producer_keeps_producer_only_configs(self):
+        """Without for_consumer, producer-only configs are retained."""
         _, auth = get_cluster_config("it_managed")
         self.assertIn("retries", auth)
 
     def test_unknown_profile_returns_empty(self):
+        """An unknown profile returns empty servers/auth so callers no-op."""
         servers, auth = get_cluster_config("does-not-exist")
         self.assertEqual(servers, [])
         self.assertEqual(auth, {})

--- a/tests/core/test_kafka.py
+++ b/tests/core/test_kafka.py
@@ -4,6 +4,7 @@ from unittest.mock import DEFAULT, Mock, patch
 from django.test import TestCase, override_settings
 from core.kafka import RBACProducer, get_cluster_config
 from kafka.errors import KafkaError, KafkaTimeoutError
+from tests.identity_request import IdentityRequest
 
 IT_MANAGED_CLUSTER = {
     "servers": ["it-broker:9096"],
@@ -98,7 +99,7 @@ class KafkaTests(TestCase):
 
 
 @override_settings(KAFKA_CLUSTERS={"it_managed": IT_MANAGED_CLUSTER})
-class GetClusterConfigTests(TestCase):
+class GetClusterConfigTests(IdentityRequest):
     """Tests for the named cluster-profile helper."""
 
     def test_returns_servers_and_auth_for_known_profile(self):
@@ -136,7 +137,7 @@ class GetClusterConfigTests(TestCase):
         self.assertNotIn("injected", auth2)
 
 
-class RBACProducerClusterSelectionTests(TestCase):
+class RBACProducerClusterSelectionTests(IdentityRequest):
     """RBACProducer selects the correct cluster by profile without affecting the default path."""
 
     @override_settings(

--- a/tests/core/test_kafka.py
+++ b/tests/core/test_kafka.py
@@ -1,9 +1,21 @@
 from copy import deepcopy
 from unittest.mock import DEFAULT, Mock, patch
 
-from django.test import TestCase
-from core.kafka import RBACProducer
+from django.test import TestCase, override_settings
+from core.kafka import RBACProducer, get_cluster_config
 from kafka.errors import KafkaError, KafkaTimeoutError
+
+IT_MANAGED_CLUSTER = {
+    "servers": ["it-broker:9096"],
+    "auth": {
+        "bootstrap_servers": ["it-broker:9096"],
+        "sasl_plain_username": "it-user",
+        "sasl_plain_password": "it-pass",
+        "sasl_mechanism": "SCRAM-SHA-512",
+        "security_protocol": "SASL_SSL",
+        "retries": 5,  # producer-only
+    },
+}
 
 
 def copy_call_args(mock):
@@ -83,6 +95,76 @@ class KafkaTests(TestCase):
             MockKafkaProducer.get_producer.side_effect = mock_logger.info("Kafka producer initialized successfully")
 
         mock_logger.info.assert_any_call("Kafka producer initialized successfully")
+
+
+@override_settings(KAFKA_CLUSTERS={"it_managed": IT_MANAGED_CLUSTER})
+class GetClusterConfigTests(TestCase):
+    """Tests for the named cluster-profile helper."""
+
+    def test_returns_servers_and_auth_for_known_profile(self):
+        servers, auth = get_cluster_config("it_managed")
+        self.assertEqual(servers, ["it-broker:9096"])
+        self.assertEqual(auth["sasl_plain_username"], "it-user")
+        self.assertEqual(auth["security_protocol"], "SASL_SSL")
+
+    def test_strips_producer_only_configs_for_consumer(self):
+        _, auth = get_cluster_config("it_managed", for_consumer=True)
+        self.assertNotIn("retries", auth)
+        # Non-producer-only auth is preserved.
+        self.assertEqual(auth["sasl_mechanism"], "SCRAM-SHA-512")
+
+    def test_producer_keeps_producer_only_configs(self):
+        _, auth = get_cluster_config("it_managed")
+        self.assertIn("retries", auth)
+
+    def test_unknown_profile_returns_empty(self):
+        servers, auth = get_cluster_config("does-not-exist")
+        self.assertEqual(servers, [])
+        self.assertEqual(auth, {})
+
+    def test_returns_copies_not_references(self):
+        """Mutating the returned values must not corrupt the registry."""
+        servers, auth = get_cluster_config("it_managed")
+        servers.append("mutated")
+        auth["injected"] = True
+        servers2, auth2 = get_cluster_config("it_managed")
+        self.assertNotIn("mutated", servers2)
+        self.assertNotIn("injected", auth2)
+
+
+class RBACProducerClusterSelectionTests(TestCase):
+    """RBACProducer selects the correct cluster by profile without affecting the default path."""
+
+    @override_settings(
+        DEVELOPMENT=False,
+        MOCK_KAFKA=False,
+        KAFKA_ENABLED=True,
+        KAFKA_AUTH={"bootstrap_servers": ["clowder:9092"], "sasl_plain_username": "clowder-user"},
+        KAFKA_SERVERS=["clowder:9092"],
+        KAFKA_CLUSTERS={"it_managed": IT_MANAGED_CLUSTER},
+    )
+    @patch("core.kafka.KafkaProducer")
+    def test_default_producer_uses_clowder_settings(self, mock_producer):
+        """Default RBACProducer() reads settings.KAFKA_AUTH directly (Clowder path unchanged)."""
+        RBACProducer().get_producer()
+        _, kwargs = mock_producer.call_args
+        self.assertEqual(kwargs["sasl_plain_username"], "clowder-user")
+
+    @override_settings(
+        DEVELOPMENT=False,
+        MOCK_KAFKA=False,
+        KAFKA_ENABLED=True,
+        KAFKA_AUTH={"bootstrap_servers": ["clowder:9092"], "sasl_plain_username": "clowder-user"},
+        KAFKA_SERVERS=["clowder:9092"],
+        KAFKA_CLUSTERS={"it_managed": IT_MANAGED_CLUSTER},
+    )
+    @patch("core.kafka.KafkaProducer")
+    def test_it_managed_producer_uses_profile(self, mock_producer):
+        """RBACProducer(cluster="it_managed") builds from the it_managed profile, not Clowder."""
+        RBACProducer(cluster="it_managed").get_producer()
+        _, kwargs = mock_producer.call_args
+        self.assertEqual(kwargs["sasl_plain_username"], "it-user")
+        self.assertEqual(kwargs["security_protocol"], "SASL_SSL")
 
 
 class SendKafkaMessageTests(TestCase):

--- a/tests/management/principal/test_kafka_cleaner.py
+++ b/tests/management/principal/test_kafka_cleaner.py
@@ -309,6 +309,22 @@ def create_mock_kafka_message(message_body, partition=0, offset=0):
     return mock_message
 
 
+IT_MANAGED_KAFKA_CLUSTERS = {
+    "it_managed": {
+        "servers": ["it-broker-1:9096", "it-broker-2:9096"],
+        "auth": {
+            "bootstrap_servers": ["it-broker-1:9096", "it-broker-2:9096"],
+            "sasl_plain_username": "it-user",
+            "sasl_plain_password": "it-pass",
+            "sasl_mechanism": "SCRAM-SHA-512",
+            "security_protocol": "SASL_SSL",
+            "retries": 5,
+        },
+    },
+}
+
+
+@override_settings(KAFKA_CLUSTERS=IT_MANAGED_KAFKA_CLUSTERS)
 class PrincipalKafkaTests(IdentityRequest):
     """Test the principal processor functions with Kafka."""
 
@@ -368,6 +384,38 @@ class PrincipalKafkaTests(IdentityRequest):
         self.assertIn("test-rbac-service", group_id)
         # Verify it includes the topic discriminator
         self.assertIn("principal-cleanup", group_id)
+
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    def test_consumer_targets_it_managed_cluster(self, consumer_mock):
+        """The cleanup consumer connects to the IT-managed cluster, not the Clowder one."""
+        consumer_instance = MagicMock()
+        consumer_instance.__iter__.return_value = iter([])
+        consumer_mock.return_value = consumer_instance
+
+        process_principal_events_from_kafka()
+
+        consumer_mock.assert_called_once()
+        call_kwargs = consumer_mock.call_args[1]
+        self.assertEqual(
+            call_kwargs["bootstrap_servers"],
+            ["it-broker-1:9096", "it-broker-2:9096"],
+        )
+        # SASL auth from the it_managed profile is forwarded to the consumer...
+        self.assertEqual(call_kwargs["sasl_plain_username"], "it-user")
+        self.assertEqual(call_kwargs["sasl_mechanism"], "SCRAM-SHA-512")
+        self.assertEqual(call_kwargs["security_protocol"], "SASL_SSL")
+        # ...but producer-only configs are stripped so KafkaConsumer does not reject them.
+        self.assertNotIn("retries", call_kwargs)
+
+    @patch("management.principal.cleaner.KafkaConsumer")
+    @patch("management.principal.cleaner.settings.KAFKA_PRINCIPAL_CLEANUP_TOPIC", "test-topic")
+    @override_settings(KAFKA_CLUSTERS={})
+    def test_consumer_no_ops_when_it_managed_unconfigured(self, consumer_mock):
+        """With no IT-managed cluster configured, the consumer safely no-ops (no Clowder fallback)."""
+        process_principal_events_from_kafka()
+
+        consumer_mock.assert_not_called()
 
     @patch(
         "management.principal.proxy.PrincipalProxy._request_principals",


### PR DESCRIPTION
[Feat] Adding in connection for the IT managed kafka cluster. Found from connection errors

[RHCLOUD-42232](https://redhat.atlassian.net/browse/RHCLOUD-42232)

## Description of Intent of Change(s)
Introduces a small named Kafka cluster-profile abstraction and uses it to point the principal-cleanup consumer and its DLQ producer at the IT-Managed Kafka cluster (AWS MSK), while every other RBAC Kafka path stays on the Clowder/ConsoleDot cluster.

Only the cleanup consumer + DLQ move to it_managed.

#### Why

After enabling Kafka shadow mode in stage, the principal-cleanup consumer fails with:

Topic stage.canonical.user.private not found in cluster metadata

(spinning ~10×/sec, never consuming).

Root cause is a cross-cluster wiring gap, not a code bug or ACL issue: RBAC builds a single Kafka client config from Clowder (LoadedConfig.kafka.brokers), which points at the ConsoleDot cluster (hosts platform.* / outbox.event.*). The principal-cleanup topics — stage.canonical.user.private and stage.hcc-access-management.dlq.private — live on a separate IT-Managed cluster. The consumer connects with valid Clowder creds but the cluster has no metadata for that topic.

This is the first permanent use of a second Kafka cluster in RBAC, part of the company-wide UMB→Kafka shift; more IT-managed topics will follow, so the wiring is done as a reusable profile rather than a one-off.


## Local Testing
- Extended tests/core/test_kafka.py and tests/management/principal/test_kafka_cleaner.py: cluster-config helper (producer-only stripping, copies, unknown-profile), consumer targets it_managed, no-op guard when unconfigured, and default RBACProducer() unchanged vs cluster="it_managed".
- 158 tests pass across test_kafka, test_kafka_consumer, test_kafka_cleaner, verified under both CLOWDER_ENABLED=False and CLOWDER_ENABLED=True.
- flake8 + black clean.

## Checklist
- [ ] if API spec changes are required, is the spec updated?
- [ ] are there any pre/post merge actions required? if so, document here.
- [ ] are theses changes covered by unit tests?
- [ ] if warranted, are documentation changes accounted for?
- [ ] does this require migration changes?
  - [ ] if yes, are they backwards compatible?
- [ ] is there known, direct impact to dependent teams/components?
  - [ ] if yes, how will this be handled?

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Practices Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices


[RHCLOUD-42232]: https://redhat.atlassian.net/browse/RHCLOUD-42232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting principal-cleanup processing to a separately managed Kafka cluster.
  * Added optional deployment configuration for the cluster’s connection and authentication settings.
  * Added cluster selection while preserving the existing default Kafka connection.

* **Bug Fixes**
  * Prevented principal cleanup from falling back to the default Kafka cluster when the separate cluster is unavailable.

* **Tests**
  * Added coverage for cluster selection, authentication handling, configuration isolation, and safe behavior when settings are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->