### PR TITLE
[RHCLOUD-49755] Add internal opt-in/opt-out API

### DIFF
--- a/rbac/internal/urls.py
+++ b/rbac/internal/urls.py
@@ -139,6 +139,7 @@ urlpatterns = [
     path("api/disaster_recovery/reconcile/", views.disaster_recovery_reconcile),
     path("api/utils/kessel_parity_check/", views.kessel_parity_check),
     path("api/utils/bootstrap_users_from_user_ids/", views.bootstrap_users_from_user_ids),
+    path("api/utils/tenant_v2_opt_in/<str:org_id>/", views.update_tenant_v2_opt_in),
 ]
 
 urlpatterns.extend(integration_urlpatterns)

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -3448,9 +3448,15 @@ def update_tenant_v2_opt_in(request, org_id: str):
                 {"error": "expected body to be a JSON object: " + str(e)}, status=status.HTTP_400_BAD_REQUEST
             )
 
+        if not isinstance(body, dict):
+            return JsonResponse(
+                {"error": f"expected body to be a JSON object, but got: {body}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         if not {"v2_opted_in"}.issuperset(body.keys()):
             return JsonResponse(
-                {"error": f"expected body to contain only v2_opted_in, but found: " f"{list(body.keys())}"},
+                {"error": f"expected body to contain only v2_opted_in, but found: {list(body.keys())}"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/rbac/internal/views.py
+++ b/rbac/internal/views.py
@@ -67,6 +67,7 @@ from kessel.relations.v1beta1 import (
     relation_tuples_pb2,
     relation_tuples_pb2_grpc,
 )
+from management.atomic_transactions import atomic_with_retry
 from management.audit_log.model import AuditLog
 from management.cache import JWTCache, TenantCache
 from management.group.relation_api_dual_write_group_handler import RelationApiDualWriteGroupHandler
@@ -117,7 +118,9 @@ from management.tasks import (
     run_seeds_in_worker,
     run_sync_schemas_in_worker,
 )
+from management.tenant_mapping.exceptions import TenantNotBootstrappedError
 from management.tenant_mapping.model import TenantMapping
+from management.tenant_mapping.v2_activation import InvalidV2OptOutError, is_v2_opted_in, set_v2_opt_in_state
 from management.tenant_service.v2 import V2TenantBootstrapService
 from management.utils import (
     create_client_channel,
@@ -3411,3 +3414,59 @@ def bootstrap_users_from_user_ids(request):
     )
 
     return JsonResponse({"dry_run": dry_run, "results": results}, status=200)
+
+
+@require_http_methods(["GET", "PATCH"])
+@atomic_with_retry(retries=3)
+def update_tenant_v2_opt_in(request, org_id: str):
+    """
+    Update a tenant's V2 opt-in status.
+
+    GET /_private/api/utils/tenant_v2_opt_in/<org_id>/
+    PATCH /_private/api/utils/tenant_v2_opt_in/<org_id>/
+
+    The GET method returns the tenant's current opt-in status. The PATCH method can be used to opt a tenant into or
+    out of V2. (Note that opting out is not possible with the public API, only with this API.)
+
+    PATCH expects a JSON body with a boolean field "v2_opted_in".
+    """
+    tenant = Tenant.objects.filter(org_id=org_id).first()
+
+    if tenant is None:
+        return JsonResponse({"error": f"Org ID {org_id!r} not found."}, status=status.HTTP_404_NOT_FOUND)
+
+    def _get_response():
+        return JsonResponse({"v2_opted_in": is_v2_opted_in(tenant)})
+
+    if request.method == "GET":
+        return _get_response()
+    elif request.method == "PATCH":
+        try:
+            body = json.loads(request.body)
+        except Exception as e:
+            return JsonResponse(
+                {"error": "expected body to be a JSON object: " + str(e)}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if not {"v2_opted_in"}.issuperset(body.keys()):
+            return JsonResponse(
+                {"error": f"expected body to contain only v2_opted_in, but found: " f"{list(body.keys())}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if "v2_opted_in" not in body:
+            return _get_response()
+
+        requested_state = body["v2_opted_in"]
+
+        if not isinstance(requested_state, bool):
+            return JsonResponse({"error": "expected v2_opted_in to be a bool"}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            set_v2_opt_in_state(tenant, requested_state)
+        except (TenantNotBootstrappedError, InvalidV2OptOutError) as e:
+            return JsonResponse({"error": str(e)}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+        return JsonResponse({"v2_opted_in": requested_state})
+    else:
+        raise AssertionError(f"Unexpected method: {request.method}")

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -5931,6 +5931,7 @@ class InternalOptInViewsetTests(BaseInternalViewsetTests):
 
         response = self._patch({"v2_opted_in": True})
         self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertFalse(is_v2_opted_in(self.tenant))
 
     def test_opt_out(self):
         set_v2_opt_in_state(self.tenant, True)
@@ -5951,10 +5952,12 @@ class InternalOptInViewsetTests(BaseInternalViewsetTests):
 
         self._assert_response(response, {"v2_opted_in": False})
         self.assertFalse(is_v2_opted_in(self.tenant))
+        self.assertFalse(is_v2_opted_in(self.tenant))
 
     def test_invalid_patch(self):
         response = self._patch({"something": "else"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(is_v2_opted_in(self.tenant))
 
     def test_not_found(self):
         response = self.client.get(self._url_for("invalid_org"), **self.request.META)

--- a/tests/internal/test_views.py
+++ b/tests/internal/test_views.py
@@ -54,6 +54,7 @@ from management.role.relation_api_dual_write_handler import (
 )
 from management.role.user_source import SourceKey
 from management.tenant_mapping.model import TenantMapping
+from management.tenant_mapping.v2_activation import is_v2_opted_in, set_v2_opt_in_state, ensure_v2_write_activated
 from management.tenant_service.v1 import V1TenantBootstrapService
 from management.tenant_service.v2 import V2TenantBootstrapService
 from management.workspace.model import Workspace
@@ -5885,6 +5886,79 @@ class KesselParityCheckEndpointTests(BaseInternalViewsetTests):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("non-empty strings", response.content.decode())
+
+
+@override_settings(ATOMIC_RETRY_DISABLED=True)
+class InternalOptInViewsetTests(BaseInternalViewsetTests):
+    def setUp(self):
+        super().setUp()
+        bootstrap_tenant_for_v2_test(self.tenant)
+
+        self.url = self._url_for(self.tenant.org_id)
+
+    def _url_for(self, org_id: str):
+        return f"/_private/api/utils/tenant_v2_opt_in/{org_id}/"
+
+    def _get(self):
+        return self.client.get(self.url, **self.request.META)
+
+    def _patch(self, body):
+        return self.client.patch(self.url, body, content_type="application/json", **self.request.META)
+
+    def _assert_response(self, response, body, status: int = 200):
+        self.assertEqual(json.loads(response.content), body)
+        self.assertEqual(response.status_code, status)
+
+    def test_get(self):
+        self.assertFalse(is_v2_opted_in(self.tenant))
+
+        response = self._get()
+        self._assert_response(response, {"v2_opted_in": False})
+
+        set_v2_opt_in_state(self.tenant, True)
+
+        response = self._get()
+        self._assert_response(response, {"v2_opted_in": True})
+
+    def test_opt_in(self):
+        response = self._patch({"v2_opted_in": True})
+
+        self._assert_response(response, {"v2_opted_in": True})
+        self.assertTrue(is_v2_opted_in(self.tenant))
+
+    def test_invalid_opt_in(self):
+        TenantMapping.objects.filter(tenant=self.tenant).delete()
+
+        response = self._patch({"v2_opted_in": True})
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+    def test_opt_out(self):
+        set_v2_opt_in_state(self.tenant, True)
+        response = self._patch({"v2_opted_in": False})
+
+        self._assert_response(response, {"v2_opted_in": False})
+        self.assertFalse(is_v2_opted_in(self.tenant))
+
+    def test_invalid_opt_out(self):
+        ensure_v2_write_activated(self.tenant)
+        response = self._patch({"v2_opted_in": False})
+
+        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertTrue(is_v2_opted_in(self.tenant))
+
+    def test_empty_patch(self):
+        response = self._patch({})
+
+        self._assert_response(response, {"v2_opted_in": False})
+        self.assertFalse(is_v2_opted_in(self.tenant))
+
+    def test_invalid_patch(self):
+        response = self._patch({"something": "else"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_not_found(self):
+        response = self.client.get(self._url_for("invalid_org"), **self.request.META)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 @override_settings(KAFKA_ENABLED=True, RBAC_KAFKA_CONSUMER_TOPIC="test-topic")


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-49755](https://redhat.atlassian.net/browse/RHCLOUD-49755)

## Description of Intent of Change(s)
Add internal API to update a tenant's V2 opt-in state.

[RHCLOUD-49755]: https://redhat.atlassian.net/browse/RHCLOUD-49755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an internal endpoint for viewing and updating a tenant’s V2 opt-in status.
  - Supports retrieving the current status and changing opt-in state through validated requests.

- **Bug Fixes**
  - Added clear error responses for missing tenants, invalid request bodies, unbootstrapped tenants, and unsupported opt-out changes.
  - Failed or invalid updates leave the tenant’s opt-in state unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->