### PR TITLE
fix(inventory): accept protobuf relationships from Kafka [RHCLOUD-50983]

### DIFF
--- a/rbac/management/inventory_replicator/inventory_api_replicator.py
+++ b/rbac/management/inventory_replicator/inventory_api_replicator.py
@@ -36,6 +36,7 @@ from kessel.inventory.v1beta2 import (
     tuple_service_pb2_grpc,
 )
 from management.inventory_replicator.inventory_replicator import InventoryReplicator, ReplicationEvent
+from management.inventory_replicator.types import RelationTuple
 from management.utils import create_client_channel_inventory, get_inventory_auth_metadata
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -138,7 +139,10 @@ class InventoryApiReplicator(InventoryReplicator):
             # Build request with optional fencing check
             request_kwargs = {
                 "upsert": True,
-                "tuples": [relationship.as_message() for relationship in relationships],
+                "tuples": [
+                    relationship.as_message() if isinstance(relationship, RelationTuple) else relationship
+                    for relationship in relationships
+                ],
             }
 
             if fencing_check is not None:

--- a/tests/management/inventory_replicator/__init__.py
+++ b/tests/management/inventory_replicator/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Inventory API replication."""

--- a/tests/management/inventory_replicator/test_inventory_api_replicator.py
+++ b/tests/management/inventory_replicator/test_inventory_api_replicator.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the Inventory API replicator."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from management.inventory_replicator.inventory_api_replicator import InventoryApiReplicator
+from management.inventory_replicator.types import ObjectReference, ObjectType, RelationTuple, SubjectReference
+
+
+def make_relation_tuple():
+    """Build a valid relationship for Inventory API request tests."""
+    return RelationTuple(
+        resource=ObjectReference(type=ObjectType(namespace="rbac", name="group"), id="group-1"),
+        relation="member",
+        subject=SubjectReference(
+            subject=ObjectReference(type=ObjectType(namespace="rbac", name="principal"), id="user-1")
+        ),
+    )
+
+
+class InventoryApiReplicatorTests(TestCase):
+    """Test relationship writes to the Inventory API."""
+
+    @patch("management.inventory_replicator.inventory_api_replicator.tuple_service_pb2_grpc.KesselTupleServiceStub")
+    @patch("management.inventory_replicator.inventory_api_replicator.create_client_channel_inventory")
+    @patch("management.inventory_replicator.inventory_api_replicator.get_inventory_auth_metadata", return_value=[])
+    def test_write_relationships_accepts_protobuf_relationships(
+        self, mock_auth_metadata, mock_create_channel, mock_stub_class
+    ):
+        """Kafka-decoded protobuf relationships are sent to CreateTuples unchanged."""
+        relationship = make_relation_tuple().as_message()
+        mock_stub = MagicMock()
+        mock_stub_class.return_value = mock_stub
+
+        InventoryApiReplicator().write_relationships([relationship])
+
+        request = mock_stub.CreateTuples.call_args.args[0]
+        self.assertTrue(request.upsert)
+        self.assertEqual(list(request.tuples), [relationship])

--- a/tests/management/inventory_replicator/test_inventory_api_replicator.py
+++ b/tests/management/inventory_replicator/test_inventory_api_replicator.py
@@ -55,3 +55,40 @@ class InventoryApiReplicatorTests(TestCase):
         request = mock_stub.CreateTuples.call_args.args[0]
         self.assertTrue(request.upsert)
         self.assertEqual(list(request.tuples), [relationship])
+
+    @patch("management.inventory_replicator.inventory_api_replicator.tuple_service_pb2_grpc.KesselTupleServiceStub")
+    @patch("management.inventory_replicator.inventory_api_replicator.create_client_channel_inventory")
+    @patch("management.inventory_replicator.inventory_api_replicator.get_inventory_auth_metadata", return_value=[])
+    def test_write_relationships_converts_relation_tuples(
+        self, mock_auth_metadata, mock_create_channel, mock_stub_class
+    ):
+        """RelationTuple inputs are converted via as_message before sending."""
+        relation_tuple = make_relation_tuple()
+        expected = relation_tuple.as_message()
+        mock_stub = MagicMock()
+        mock_stub_class.return_value = mock_stub
+
+        InventoryApiReplicator().write_relationships([relation_tuple])
+
+        request = mock_stub.CreateTuples.call_args.args[0]
+        self.assertTrue(request.upsert)
+        self.assertEqual(list(request.tuples), [expected])
+
+    @patch("management.inventory_replicator.inventory_api_replicator.tuple_service_pb2_grpc.KesselTupleServiceStub")
+    @patch("management.inventory_replicator.inventory_api_replicator.create_client_channel_inventory")
+    @patch("management.inventory_replicator.inventory_api_replicator.get_inventory_auth_metadata", return_value=[])
+    def test_write_relationships_handles_mixed_input(self, mock_auth_metadata, mock_create_channel, mock_stub_class):
+        """Mixed RelationTuple and protobuf Relationship inputs are handled correctly."""
+        relation_tuple = make_relation_tuple()
+        protobuf_relationship = make_relation_tuple().as_message()
+        mock_stub = MagicMock()
+        mock_stub_class.return_value = mock_stub
+
+        InventoryApiReplicator().write_relationships([relation_tuple, protobuf_relationship])
+
+        request = mock_stub.CreateTuples.call_args.args[0]
+        self.assertTrue(request.upsert)
+        tuples = list(request.tuples)
+        self.assertEqual(len(tuples), 2)
+        self.assertEqual(tuples[0], relation_tuple.as_message())
+        self.assertEqual(tuples[1], protobuf_relationship)


### PR DESCRIPTION
## Link(s) to Jira
- https://issues.redhat.com/browse/RHCLOUD-50983

## Summary

- Prevent the Kafka replication consumer from calling a domain-only method on protobuf Relationship messages.
- Preserve RelationTuple conversion for direct domain callers.
- Add a regression test that verifies a Kafka-shaped protobuf is sent to CreateTuples unchanged.

## Problem

The consumer decodes relations_to_add and relations_to_remove from the Debezium payload with ParseDict into Kessel protobuf Relationship objects. It then passes those objects to InventoryApiReplicator.write_relationships.

Before this change, write_relationships assumed every input was a RelationTuple and called as_message on each item. as_message belongs to RelationTuple, not to a protobuf Relationship, so the consumer failed with AttributeError: as_message before it made its gRPC CreateTuples request.

### Failing example

1. A Debezium external_user_update contains two relations_to_add entries.
2. The Kafka consumer parses each entry to relationship_pb2.Relationship.
3. write_relationships evaluates relationship.as_message.
4. Python raises AttributeError: as_message.
5. The offset is not committed and the retry loop repeats the same failure.

### Fixed behavior

- For a RelationTuple input, write_relationships converts it with as_message.
- For a protobuf Relationship input from the Kafka consumer, write_relationships forwards it unchanged to CreateTuples.

This lets the stuck message be processed after deployment without manually skipping its Kafka offset.

## Testing

- tox -e py312-fast -- tests.management.inventory_replicator.test_inventory_api_replicator
- Pre-commit hooks: flake8, Black, django-upgrade, secret scan