### PR TITLE
chore: skip jira ticket check for red-hat-konflux bot PRs [RHCLOUD-51006]

### DIFF
--- a/.github/workflows/jira-ticket-check.yml
+++ b/.github/workflows/jira-ticket-check.yml
@@ -18,6 +18,7 @@ jobs:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'bot')
       && !startsWith(github.event.pull_request.title, 'chore(deps):')
+      && github.event.pull_request.user.login != 'red-hat-konflux[bot]'
     steps:
       - name: Check PR title for JIRA ticket
         env:


### PR DESCRIPTION
## Summary
- Skip the JIRA ticket check for PRs opened by the `red-hat-konflux[bot]` GitHub App user
- Konflux automation PRs (dependency updates, image bumps) don't have JIRA tickets and shouldn't be blocked

## Test plan
- [ ] Verify the workflow skips when `github.event.pull_request.user.login == 'red-hat-konflux[bot]'`
- [ ] Verify the workflow still runs for normal PRs without the `bot` label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added commands to start, stop, and monitor local RBAC and full integration environments.
  - Added a complete local development stack with Kafka, Debezium, PostgreSQL, Redis, RBAC, and related services.
  - Added workspace creation and read-your-writes verification workflows.
  - Added a local Zed CLI for configuring and checking workspace permissions.

- **Documentation**
  - Added setup guidance, service endpoints, configuration options, and troubleshooting steps for the full local stack.

- **Bug Fixes**
  - Improved container runtime detection, logging reliability, startup readiness checks, and local configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->