### PR TITLE
fix(inventory): return 503 on OAuth outage [RHCLOUD-51009]

### DIFF
--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -55,6 +55,7 @@ Defined in `api/common/renderers.py`. A thin `JSONRenderer` subclass with `media
 - `RequiredFieldError(field_name)` -- missing required field. Stores `field_name`.
 - `InvalidFieldError(field, message)` -- invalid field value. Stores `field`.
 - `NotFoundError(resource_type, resource_id)` -- resource not found.
+- `InventoryAuthUnavailableError` -- Inventory API OAuth token service temporarily unavailable (503 with `Retry-After`).
 
 ### Role v2 (`management/role/v2_exceptions.py`)
 Hierarchy rooted at `RoleV2Error`:

--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -265,7 +265,10 @@ namespace Problems {
         type: ProblemType.ServiceUnavailable,
         title: "A downstream dependency is temporarily unavailable. Please retry shortly.",
         @example("Inventory authorization is temporarily unavailable. Please try again shortly.")
-        detail: string
+        detail: string,
+        @header("Retry-After")
+        @example("1")
+        retryAfter: string
     }
 
     @error

--- a/docs/source/specs/typespec/main.tsp
+++ b/docs/source/specs/typespec/main.tsp
@@ -216,6 +216,7 @@ namespace Problems {
         InvalidRequest:"http://project-kessel.org/problems/invalid-request",
         AlreadyExists:"http://project-kessel.org/problems/already-exists",
         WorkspaceNotEmpty:"http://project-kessel.org/problems/workspace-not-empty",
+        ServiceUnavailable:"http://project-kessel.org/problems/service-unavailable",
     }
 
     @error
@@ -257,6 +258,14 @@ namespace Problems {
     model Problem500 extends ProblemDetails<Status = 500>{
         type: ProblemType.InternalError,
         title: "Unexpected error occurred.";
+    }
+
+    @error
+    model Problem503 extends ProblemDetails<Status = 503>{
+        type: ProblemType.ServiceUnavailable,
+        title: "A downstream dependency is temporarily unavailable. Please retry shortly.",
+        @example("Inventory authorization is temporarily unavailable. Please try again shortly.")
+        detail: string
     }
 
     @error
@@ -558,7 +567,7 @@ namespace Workspaces {
         @doc("When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.")
         @example(false)
         @query with_ancestry?: boolean = false;
-    ): WorkspaceListResponse | Problems.CommonProblems;
+    ): WorkspaceListResponse | Problems.CommonProblems | Problems.Problem503;
 
     @doc("Create workspace in tenant")
     @summary("Create workspace in tenant")
@@ -812,7 +821,7 @@ namespace Workspaces {
         @query order_by?: string = "name";
 
         @body body: WorkspaceQueryRequest;
-    ): WorkspaceListResponse | Problems.CommonProblems;
+    ): WorkspaceListResponse | Problems.CommonProblems | Problems.Problem503;
 }
 
 @route("/role-bindings/")

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -535,7 +535,7 @@
       "get": {
         "operationId": "RoleBindings_listBySubject",
         "summary": "List role bindings grouped by subject",
-        "description": "List role bindings grouped by subject. subject_type (optional) is user or group only, with subject_id as UUID. granted_subject_type, granted_subject_id, and granted_subject.principal.user_id are not query parameters on this path\u2014use GET /role-bindings/ for those filters.",
+        "description": "List role bindings grouped by subject. subject_type (optional) is user or group only, with subject_id as UUID. granted_subject_type, granted_subject_id, and granted_subject.principal.user_id are not query parameters on this path—use GET /role-bindings/ for those filters.",
         "parameters": [
           {
             "name": "limit",
@@ -2017,6 +2017,14 @@
           },
           "503": {
             "description": "Service unavailable.",
+            "headers": {
+              "Retry-After": {
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2247,6 +2255,14 @@
           },
           "503": {
             "description": "Service unavailable.",
+            "headers": {
+              "Retry-After": {
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/docs/source/specs/v2/openapi.json
+++ b/docs/source/specs/v2/openapi.json
@@ -535,7 +535,7 @@
       "get": {
         "operationId": "RoleBindings_listBySubject",
         "summary": "List role bindings grouped by subject",
-        "description": "List role bindings grouped by subject. subject_type (optional) is user or group only, with subject_id as UUID. granted_subject_type, granted_subject_id, and granted_subject.principal.user_id are not query parameters on this path—use GET /role-bindings/ for those filters.",
+        "description": "List role bindings grouped by subject. subject_type (optional) is user or group only, with subject_id as UUID. granted_subject_type, granted_subject_id, and granted_subject.principal.user_id are not query parameters on this path\u2014use GET /role-bindings/ for those filters.",
         "parameters": [
           {
             "name": "limit",
@@ -2014,6 +2014,16 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problems.Problem503"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -2231,6 +2241,16 @@
               "application/problem+json": {
                 "schema": {
                   "$ref": "#/components/schemas/Problems.Problem500"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problems.Problem503"
                 }
               }
             }
@@ -3311,6 +3331,58 @@
           }
         ]
       },
+      "Problems.Problem503": {
+        "type": "object",
+        "required": [
+          "type",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "http://project-kessel.org/problems/service-unavailable"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "enum": [
+              "A downstream dependency is temporarily unavailable. Please retry shortly."
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "example": "Inventory authorization is temporarily unavailable. Please try again shortly."
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "$ref": "#/components/schemas/Problems.ProblemType"
+              },
+              "status": {
+                "type": "number",
+                "enum": [
+                  503
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              },
+              "instance": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
+        ]
+      },
       "Problems.ProblemType": {
         "type": "string",
         "enum": [
@@ -3320,7 +3392,8 @@
           "http://project-kessel.org/problems/internal-error",
           "http://project-kessel.org/problems/invalid-request",
           "http://project-kessel.org/problems/already-exists",
-          "http://project-kessel.org/problems/workspace-not-empty"
+          "http://project-kessel.org/problems/workspace-not-empty",
+          "http://project-kessel.org/problems/service-unavailable"
         ]
       },
       "Problems.Workspace.Problem400WorkspaceNotEmpty": {

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -1280,6 +1280,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problems.Problem500'
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problems.Problem503'
       tags:
         - Workspaces
     post:
@@ -1420,6 +1426,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problems.Problem500'
+        '503':
+          description: Service unavailable.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problems.Problem503'
       tags:
         - Workspaces
       requestBody:
@@ -2146,6 +2158,40 @@ components:
             instance:
               type: string
               format: uri
+    Problems.Problem503:
+      type: object
+      required:
+        - type
+        - title
+        - detail
+      properties:
+        type:
+          type: string
+          enum:
+            - http://project-kessel.org/problems/service-unavailable
+        title:
+          type: string
+          enum:
+            - A downstream dependency is temporarily unavailable. Please retry shortly.
+        detail:
+          type: string
+          example: Inventory authorization is temporarily unavailable. Please try again shortly.
+      allOf:
+        - type: object
+          properties:
+            type:
+              $ref: '#/components/schemas/Problems.ProblemType'
+            status:
+              type: number
+              enum:
+                - 503
+            title:
+              type: string
+            detail:
+              type: string
+            instance:
+              type: string
+              format: uri
     Problems.ProblemType:
       type: string
       enum:
@@ -2156,6 +2202,7 @@ components:
         - http://project-kessel.org/problems/invalid-request
         - http://project-kessel.org/problems/already-exists
         - http://project-kessel.org/problems/workspace-not-empty
+        - http://project-kessel.org/problems/service-unavailable
     Problems.Workspace.Problem400WorkspaceNotEmpty:
       type: object
       required:

--- a/docs/source/specs/v2/openapi.yaml
+++ b/docs/source/specs/v2/openapi.yaml
@@ -1282,6 +1282,11 @@ paths:
                 $ref: '#/components/schemas/Problems.Problem500'
         '503':
           description: Service unavailable.
+          headers:
+            Retry-After:
+              required: true
+              schema:
+                type: string
           content:
             application/problem+json:
               schema:
@@ -1428,6 +1433,11 @@ paths:
                 $ref: '#/components/schemas/Problems.Problem500'
         '503':
           description: Service unavailable.
+          headers:
+            Retry-After:
+              required: true
+              schema:
+                type: string
           content:
             application/problem+json:
               schema:

--- a/rbac/api/common/exception_handler.py
+++ b/rbac/api/common/exception_handler.py
@@ -24,7 +24,12 @@ from django.http import Http404
 from management.authorization.invalid_token import InvalidTokenError
 from management.authorization.missing_authorization import MissingAuthorizationError
 from management.authorization.unable_meet_prerequisites import UnableMeetPrerequisitesError
-from management.exceptions import InvalidFieldError, NotFoundError, RequiredFieldError
+from management.exceptions import (
+    InvalidFieldError,
+    InventoryAuthUnavailableError,
+    NotFoundError,
+    RequiredFieldError,
+)
 from management.role.v2_exceptions import RolesNotFoundError
 from management.utils import api_path_prefix, v2response_error_from_errors
 from rest_framework import status
@@ -143,6 +148,17 @@ def custom_exception_handler_v2(exc, context):
             content_type="application/json",
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+    elif isinstance(exc, InventoryAuthUnavailableError):
+        response = Response(
+            data=_v2_generate_error_data_payload_response(
+                detail="Inventory authorization is temporarily unavailable. Please try again shortly.",
+                context=context,
+                http_status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            ),
+            content_type="application/problem+json",
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+        response["Retry-After"] = "1"
     elif isinstance(exc, RolesNotFoundError):
         # Convert RolesNotFoundError to Http404 and let standard handler process it
         response = exception_handler(Http404(str(exc)), context)
@@ -230,5 +246,16 @@ def custom_exception_handler(exc, context):
             content_type="application/json",
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+    elif isinstance(exc, InventoryAuthUnavailableError):
+        response = Response(
+            data=_generate_error_data_payload_response(
+                detail="Inventory authorization is temporarily unavailable. Please try again shortly.",
+                context=context,
+                http_status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            ),
+            content_type="application/json",
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+        response["Retry-After"] = "1"
 
     return response

--- a/rbac/management/exceptions.py
+++ b/rbac/management/exceptions.py
@@ -50,4 +50,4 @@ class InventoryAuthUnavailableError(Exception):
 
     def __init__(self):
         """Initialize the exception with a safe client-facing message."""
-        super().__init__("Inventory API authentication is temporarily unavailable")
+        super().__init__("Inventory authorization is temporarily unavailable")

--- a/rbac/management/exceptions.py
+++ b/rbac/management/exceptions.py
@@ -43,3 +43,11 @@ class NotFoundError(Exception):
         self.resource_type = resource_type
         self.resource_id = resource_id
         super().__init__(f"{resource_type} with id '{resource_id}' not found")
+
+
+class InventoryAuthUnavailableError(Exception):
+    """Raised when the Inventory API OAuth token service is temporarily unavailable."""
+
+    def __init__(self):
+        """Initialize the exception with a safe client-facing message."""
+        super().__init__("Inventory API authentication is temporarily unavailable")

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -81,8 +81,8 @@ def get_inventory_auth_metadata() -> list:
         return []
     try:
         token_response = inventory_auth_credentials.get_token()
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
-        token_endpoint_host = urlparse(settings.INVENTORY_API_TOKEN_URL).netloc or "unknown"
+    except requests.exceptions.RequestException as exc:
+        token_endpoint_host = urlparse(settings.INVENTORY_API_TOKEN_URL).hostname or "unknown"
         logger.warning(
             "Inventory API OAuth token request failed at SSO endpoint: endpoint_host=%s error_type=%s",
             token_endpoint_host,

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -24,9 +24,11 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import ClassVar, Optional, TypedDict
+from urllib.parse import urlparse
 from uuid import UUID
 
 import grpc
+import requests
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
@@ -36,6 +38,7 @@ from management.authorization.missing_authorization import MissingAuthorizationE
 from management.authorization.token_validator import TokenValidator
 from management.cache import PrincipalCache
 from management.models import Access, Group, Policy, Principal, Role
+from management.exceptions import InventoryAuthUnavailableError
 from management.permissions.principal_access import PrincipalAccessPermission
 from management.principal.it_service import ITService
 from management.principal.proxy import PrincipalProxy
@@ -76,7 +79,17 @@ def get_inventory_auth_metadata() -> list:
     """
     if not settings.INVENTORY_API_CLIENT_ID or not settings.INVENTORY_API_CLIENT_SECRET:
         return []
-    token_response = inventory_auth_credentials.get_token()
+    try:
+        token_response = inventory_auth_credentials.get_token()
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        token_endpoint_host = urlparse(settings.INVENTORY_API_TOKEN_URL).netloc or "unknown"
+        logger.warning(
+            "Inventory API OAuth token request failed at SSO endpoint: endpoint_host=%s error_type=%s",
+            token_endpoint_host,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        raise InventoryAuthUnavailableError() from exc
     if not token_response.access_token:
         raise RuntimeError("Inventory API OAuth token response did not include an access_token")
     return [("authorization", f"Bearer {token_response.access_token}")]

--- a/rbac/management/utils.py
+++ b/rbac/management/utils.py
@@ -37,8 +37,8 @@ from management.authorization.invalid_token import InvalidTokenError
 from management.authorization.missing_authorization import MissingAuthorizationError
 from management.authorization.token_validator import TokenValidator
 from management.cache import PrincipalCache
-from management.models import Access, Group, Policy, Principal, Role
 from management.exceptions import InventoryAuthUnavailableError
+from management.models import Access, Group, Policy, Principal, Role
 from management.permissions.principal_access import PrincipalAccessPermission
 from management.principal.it_service import ITService
 from management.principal.proxy import PrincipalProxy

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -82,14 +82,13 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
         try:
             has_access = is_user_allowed_v2(request, relation, workspace_id, with_ancestry=with_ancestry)
         except InventoryAuthUnavailableError:
-            logger.warning(
+            logger.debug(
                 "Inventory SSO unavailable during workspace access filtering: "
                 "user=%s org_id=%s workspace_id=%s relation=%s",
                 getattr(request.user, "username", "unknown"),
                 getattr(request.user, "org_id", "unknown"),
                 workspace_id,
                 relation,
-                exc_info=True,
             )
             raise
         except Exception as e:

--- a/rbac/management/workspace/filters.py
+++ b/rbac/management/workspace/filters.py
@@ -19,6 +19,7 @@
 import logging
 
 from feature_flags import FEATURE_FLAGS
+from management.exceptions import InventoryAuthUnavailableError
 from management.workspace.utils import permission_from_request
 from management.workspace.utils.access import is_user_allowed_v2
 from rest_framework import filters
@@ -80,6 +81,17 @@ class WorkspaceAccessFilterBackend(filters.BaseFilterBackend):
         with_ancestry = getattr(request, "with_ancestry", False) if workspace_id is None else False
         try:
             has_access = is_user_allowed_v2(request, relation, workspace_id, with_ancestry=with_ancestry)
+        except InventoryAuthUnavailableError:
+            logger.warning(
+                "Inventory SSO unavailable during workspace access filtering: "
+                "user=%s org_id=%s workspace_id=%s relation=%s",
+                getattr(request.user, "username", "unknown"),
+                getattr(request.user, "org_id", "unknown"),
+                workspace_id,
+                relation,
+                exc_info=True,
+            )
+            raise
         except Exception as e:
             logger.exception(
                 "Exception in is_user_allowed_v2: user=%s, org_id=%s, workspace_id=%s, relation=%s, error=%s",

--- a/tests/api/common/test_exception_handler.py
+++ b/tests/api/common/test_exception_handler.py
@@ -23,7 +23,12 @@ from django.test import TestCase
 from management.authorization.invalid_token import InvalidTokenError
 from management.authorization.missing_authorization import MissingAuthorizationError
 from management.authorization.unable_meet_prerequisites import UnableMeetPrerequisitesError
-from management.exceptions import InvalidFieldError, NotFoundError, RequiredFieldError
+from management.exceptions import (
+    InvalidFieldError,
+    InventoryAuthUnavailableError,
+    NotFoundError,
+    RequiredFieldError,
+)
 from management.role.v2_exceptions import RolesNotFoundError
 from rest_framework import status
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -186,6 +191,17 @@ class ExceptionHandlerTest(TestCase):
             mocked_view.basename,
             str(response.data.get("errors")[0].get("source")),
             "unexpected source view in the response for the 'UnableMeetPrerequisitesError' exception handling",
+        )
+
+    def test_inventory_auth_unavailable_exception_handled(self):
+        """Inventory auth outages return a retryable 503 instead of an unhandled 500."""
+        response = custom_exception_handler(InventoryAuthUnavailableError(), context={})
+
+        self.assertEqual(status.HTTP_503_SERVICE_UNAVAILABLE, response.status_code)
+        self.assertEqual("1", response["Retry-After"])
+        self.assertEqual(
+            "Inventory authorization is temporarily unavailable. Please try again shortly.",
+            response.data["errors"][0]["detail"],
         )
 
     def test_generate_error_data_payload_with_view_response(self):
@@ -583,6 +599,19 @@ class V2ExceptionHandlerTests(TestCase):
                 "errors": [{"message": "Unable to validate the provided token."}],
             },
         )
+
+    def test_inventory_auth_unavailable_error_returns_503(self):
+        """Inventory auth outages produce a v2 Problem Details 503 response."""
+        response = custom_exception_handler_v2(InventoryAuthUnavailableError(), self._mock_v2_context())
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.content_type, "application/problem+json")
+        self.assertEqual(response.data["status"], 503)
+        self.assertEqual(
+            response.data["detail"],
+            "Inventory authorization is temporarily unavailable. Please try again shortly.",
+        )
+        self.assertEqual(response["Retry-After"], "1")
 
     # ── Branch: RolesNotFoundError ─────────────────────────────────────
 

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -871,6 +871,45 @@ class GetInventoryAuthMetadataTests(IdentityRequest):
 
     @override_settings(INVENTORY_API_CLIENT_ID="client-id", INVENTORY_API_CLIENT_SECRET="client-secret")
     @mock.patch("management.utils.inventory_auth_credentials")
+    def test_wraps_http_error_as_unavailable(self, mock_credentials):
+        """HTTPError (e.g. SSO returns 503) is wrapped as InventoryAuthUnavailableError."""
+        mock_credentials.get_token.side_effect = requests.exceptions.HTTPError("503 Server Error")
+
+        with self.assertRaises(InventoryAuthUnavailableError) as context:
+            get_inventory_auth_metadata()
+
+        self.assertIsInstance(context.exception.__cause__, requests.exceptions.HTTPError)
+
+    @override_settings(INVENTORY_API_CLIENT_ID="client-id", INVENTORY_API_CLIENT_SECRET="client-secret")
+    @mock.patch("management.utils.inventory_auth_credentials")
+    def test_wraps_ssl_error_as_unavailable(self, mock_credentials):
+        """SSLError during token fetch is wrapped as InventoryAuthUnavailableError."""
+        mock_credentials.get_token.side_effect = requests.exceptions.SSLError("SSL handshake failed")
+
+        with self.assertRaises(InventoryAuthUnavailableError) as context:
+            get_inventory_auth_metadata()
+
+        self.assertIsInstance(context.exception.__cause__, requests.exceptions.SSLError)
+
+    @override_settings(
+        INVENTORY_API_CLIENT_ID="client-id",
+        INVENTORY_API_CLIENT_SECRET="client-secret",
+        INVENTORY_API_TOKEN_URL="https://user:pass@sso.example.com/token",
+    )
+    @mock.patch("management.utils.inventory_auth_credentials")
+    def test_logs_hostname_not_netloc(self, mock_credentials):
+        """Log message must use .hostname (no userinfo) instead of .netloc."""
+        mock_credentials.get_token.side_effect = requests.exceptions.ConnectionError("down")
+
+        with self.assertRaises(InventoryAuthUnavailableError):
+            with mock.patch("management.utils.logger") as mock_logger:
+                get_inventory_auth_metadata()
+                # The warning call should log hostname ("sso.example.com"), never netloc ("user:pass@sso.example.com")
+                args = mock_logger.warning.call_args[0]
+                self.assertEqual(args[1], "sso.example.com")
+
+    @override_settings(INVENTORY_API_CLIENT_ID="client-id", INVENTORY_API_CLIENT_SECRET="client-secret")
+    @mock.patch("management.utils.inventory_auth_credentials")
     def test_raises_when_access_token_missing(self, mock_credentials):
         """Test that a token response without an access_token raises instead of sending 'Bearer None'."""
         mock_credentials.get_token.return_value = Mock(access_token=None)

--- a/tests/management/test_utils.py
+++ b/tests/management/test_utils.py
@@ -18,8 +18,10 @@
 
 import uuid
 
+import requests
 from api.models import Tenant, User
 from management.models import Access, Group, Permission, Principal, Policy, Role
+from management.exceptions import InventoryAuthUnavailableError
 from management.principal.view import VALID_PRINCIPAL_TYPE_VALUE
 from management.utils import (
     access_for_principal,
@@ -855,6 +857,17 @@ class GetInventoryAuthMetadataTests(IdentityRequest):
         mock_credentials.get_token.side_effect = Exception("SSO unreachable")
         with self.assertRaises(Exception):
             get_inventory_auth_metadata()
+
+    @override_settings(INVENTORY_API_CLIENT_ID="client-id", INVENTORY_API_CLIENT_SECRET="client-secret")
+    @mock.patch("management.utils.inventory_auth_credentials")
+    def test_wraps_transient_token_fetch_failure(self, mock_credentials):
+        """Transient OAuth connection failures become a service-unavailable domain error."""
+        mock_credentials.get_token.side_effect = requests.exceptions.ConnectionError("SSO reset connection")
+
+        with self.assertRaises(InventoryAuthUnavailableError) as context:
+            get_inventory_auth_metadata()
+
+        self.assertIsInstance(context.exception.__cause__, requests.exceptions.ConnectionError)
 
     @override_settings(INVENTORY_API_CLIENT_ID="client-id", INVENTORY_API_CLIENT_SECRET="client-secret")
     @mock.patch("management.utils.inventory_auth_credentials")

--- a/tests/management/workspace/test_filters.py
+++ b/tests/management/workspace/test_filters.py
@@ -28,6 +28,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.models import Tenant
+from management.exceptions import InventoryAuthUnavailableError
 from management.models import Workspace
 from management.permissions.system_user_utils import SystemUserAccessResult
 from management.workspace.filters import WorkspaceAccessFilterBackend
@@ -145,6 +146,23 @@ class WorkspaceAccessFilterBackendUnitTests(TransactionTestCase):
 
         # Should return empty queryset on exception
         queryset.none.assert_called_once()
+
+    @patch("management.workspace.filters.is_user_allowed_v2")
+    @patch("management.workspace.filters.FEATURE_FLAGS")
+    def test_propagates_inventory_auth_unavailable(self, mock_flags, mock_is_user_allowed_v2):
+        """Inventory auth outages must reach the API exception handler instead of returning an empty list."""
+        mock_flags.is_workspace_access_check_v2_enabled.return_value = True
+        mock_is_user_allowed_v2.side_effect = InventoryAuthUnavailableError()
+
+        request = Mock()
+        request.method = "GET"
+        queryset = Mock()
+        view = Mock(action="list")
+
+        with self.assertRaises(InventoryAuthUnavailableError):
+            self.filter_backend.filter_queryset(request, queryset, view)
+
+        queryset.none.assert_not_called()
 
     @patch("management.workspace.filters.is_user_allowed_v2")
     @patch("management.workspace.filters.FEATURE_FLAGS")


### PR DESCRIPTION
## Summary
- classify transient Inventory OAuth connection and timeout failures
- log the SSO endpoint host and request context without secrets
- return a retryable 503 instead of an empty 200 workspace result
- preserve existing handling for unrelated filter exceptions

## Response behavior

### Before

When the SSO token request was reset:

- Permission checks could expose an unhandled `requests.exceptions.ConnectionError` as HTTP 500.
- Workspace list filtering caught the exception broadly, returned `queryset.none()`, and produced HTTP 200 with an empty workspace list. This was indistinguishable from a user with no accessible workspaces.

### After

The Inventory OAuth failure is propagated as a retryable service-unavailable response.

V2 example:

```http
HTTP/1.1 503 Service Unavailable
Retry-After: 1
Content-Type: application/problem+json
```

```json
{
  "status": 503,
  "title": "An error occurred.",
  "detail": "Inventory authorization is temporarily unavailable. Please try again shortly.",
  "errors": [
    {
      "message": "Inventory authorization is temporarily unavailable. Please try again shortly."
    }
  ]
}
```

V1 example:

```json
{
  "errors": [
    {
      "detail": "Inventory authorization is temporarily unavailable. Please try again shortly.",
      "status": 503
    }
  ]
}
```

The response tells clients to retry instead of treating an authentication outage as an empty authorization result.

## Logging

The failure is explicitly identified as an SSO token-endpoint problem without logging credentials or tokens:

```text
Inventory API OAuth token request failed at SSO endpoint: endpoint_host=sso.stage.redhat.com error_type=ConnectionError
Inventory SSO unavailable during workspace access filtering: user=<user> org_id=<org> workspace_id=None relation=view
```

## Validation
- 120 focused tests passed
- 86 focused tests passed after logging changes
- pre-commit checks passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Inventory authentication outages now return a clear temporary-unavailability response with HTTP 503 status.
  - Responses include `Retry-After: 1` to indicate that requests may be retried shortly.
  - Workspace access checks now surface authentication outages instead of treating them as empty results.

- **Documentation**
  - Added guidance for handling Inventory API authentication service interruptions.
  - Documented HTTP 503 responses and required retry headers for workspace listing and querying operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->