### PR TITLE
[RHCLOUD-51271] Don't rely on hard-coded user ID in test requests

### DIFF
--- a/tests/api/cross_access/fixtures.py
+++ b/tests/api/cross_access/fixtures.py
@@ -49,11 +49,17 @@ class CrossAccountRequestTest(IdentityRequest):
         self.replicator = InMemoryRelationReplicator(self.relations)
         self.fixture = RbacFixture(V2TenantBootstrapService(InMemoryRelationReplicator(self.relations)))
 
+        self.user_1_data = {
+            "email": "fake_user_1@example.com",
+            "username": "1111111",
+            "user_id": "1111111",
+        }
+
         self.ref_time = timezone.now()
         self.account = self.customer_data["account_id"]
         self.org_id = self.customer_data["org_id"]
         self.associate_non_admin_request_context = self._create_request_context(
-            self.customer_data, self.user_data, is_org_admin=False, is_internal=True
+            self.customer_data, self.user_1_data, is_org_admin=False, is_internal=True
         )
         self.associate_non_admin_request = self.associate_non_admin_request_context["request"]
 
@@ -63,13 +69,13 @@ class CrossAccountRequestTest(IdentityRequest):
         self.not_anemic_customer_data["account_id"] = self.not_anemic_account
         self.not_anemic_customer_data["tenant_name"] = f"acct{self.not_anemic_account}"
         self.associate_not_anemic_request_context = self._create_request_context(
-            self.not_anemic_customer_data, self.user_data, is_org_admin=False, is_internal=True
+            self.not_anemic_customer_data, self.user_1_data, is_org_admin=False, is_internal=True
         )
         self.associate_not_anemic_request = self.associate_not_anemic_request_context["request"]
         self.not_anemic_headers = self.associate_not_anemic_request_context["request"].META
 
         self.associate_admin_request_context = self._create_request_context(
-            self.customer_data, self.user_data, is_org_admin=True, is_internal=True
+            self.customer_data, self.user_1_data, is_org_admin=True, is_internal=True
         )
         self.associate_admin_request = self.associate_admin_request_context["request"]
 
@@ -112,12 +118,16 @@ class CrossAccountRequestTest(IdentityRequest):
         self.role_9 = self.fixture.new_system_role(name="role_9")
         self.role_8 = self.fixture.new_system_role(name="role_8")
 
-        Principal.objects.create(tenant=public_tenant, username="1111111", user_id="1111111")
+        Principal.objects.create(
+            tenant=public_tenant, username=self.user_1_data["username"], user_id=self.user_1_data["user_id"]
+        )
         Principal.objects.create(tenant=public_tenant, username="2222222", user_id="2222222")
+
+        user_1_id = self.user_1_data["user_id"]
 
         self.request_1 = CrossAccountRequest.objects.create(
             target_org=self.org_id,
-            user_id="1111111",
+            user_id=user_1_id,
             end_date=self.ref_time + timedelta(10),
             status="approved",
         )
@@ -130,7 +140,7 @@ class CrossAccountRequestTest(IdentityRequest):
         self.request_2.roles.add(*(self.role_1, self.role_2))
         self.request_3 = CrossAccountRequest.objects.create(
             target_org=self.another_org_id,
-            user_id="1111111",
+            user_id=user_1_id,
             end_date=self.ref_time + timedelta(10),
             status="approved",
         )
@@ -148,13 +158,13 @@ class CrossAccountRequestTest(IdentityRequest):
         )
         self.request_6 = CrossAccountRequest.objects.create(
             target_org=self.another_org_id,
-            user_id="1111111",
+            user_id=user_1_id,
             end_date=self.ref_time + timedelta(10),
             status="pending",
         )
         self.not_anemic_request_1 = CrossAccountRequest.objects.create(
             target_org=self.not_anemic_org_id,
-            user_id="1111111",
+            user_id=user_1_id,
             end_date=self.ref_time + timedelta(10),
             status="approved",
         )

--- a/tests/api/cross_access/test_view.py
+++ b/tests/api/cross_access/test_view.py
@@ -361,7 +361,7 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         notify_mock.assert_called_once_with(
             EVENT_TYPE_RH_TAM_REQUEST_CREATED,
             {
-                "username": self.user_data["username"],
+                "username": self.user_1_data["username"],
                 "request_id": response.data["request_id"],
             },
             self.data4create["target_org"],
@@ -387,7 +387,7 @@ class CrossAccountRequestViewTests(CrossAccountRequestTest):
         notify_mock.assert_called_once_with(
             EVENT_TYPE_RH_TAM_REQUEST_CREATED,
             {
-                "username": self.user_data["username"],
+                "username": self.user_1_data["username"],
                 "request_id": response.data["request_id"],
             },
             self.data4create["target_org"],

--- a/tests/identity_request.py
+++ b/tests/identity_request.py
@@ -88,7 +88,12 @@ class BaseIdentityRequest:
         # Generate unique username by appending UUID to avoid cache collisions
         base_username = cls.fake.user_name()
         unique_username = f"{base_username}_{uuid.uuid4().hex[:8]}"
-        user_data = {"username": unique_username, "email": cls.fake.email(), "user_id": cls.fake.ean8()}
+        user_data = {
+            "username": unique_username,
+            "email": cls.fake.email(),
+            # We add a prefix to ensure we don't conflict with any hard-coded user IDs.
+            "user_id": "ir-" + cls.fake.ean8(),
+        }
         return user_data
 
     def _create_service_account_data(cls) -> dict[str, str]:
@@ -141,7 +146,7 @@ class BaseIdentityRequest:
                 "username": user_data.get("username"),
                 "email": user_data.get("email"),
                 "is_org_admin": is_org_admin,
-                "user_id": "1111111",
+                "user_id": user_data.get("user_id") or ("ir-" + cls.fake.ean8()),
             }
 
         if service_account_data:

--- a/tests/rbac/test_middleware.py
+++ b/tests/rbac/test_middleware.py
@@ -1675,8 +1675,7 @@ class RequestContextMiddlewareTest(IdentityRequest):
             returned = middleware(self.request)
             self.assertIs(returned, response)
             self.assertEqual(captured["org_id"], self.customer["org_id"])
-            # user_id is hardcoded as "1111111" in _build_identity
-            self.assertEqual(captured["user_id"], "1111111")
+            self.assertEqual(captured["user_id"], self.user_data["user_id"])
             self.assertEqual(captured["user_type"], "user")
 
         ctx.run(_run)


### PR DESCRIPTION
## Link(s) to Jira
[RHCLOUD-51271](https://redhat.atlassian.net/browse/RHCLOUD-51271)

## Description of Intent of Change(s)
As the title suggests.

[RHCLOUD-51271]: https://redhat.atlassian.net/browse/RHCLOUD-51271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for cross-account requests by consistently using distinct user identities.
  * Updated identity and request-context tests to validate dynamically generated user IDs.
  * Corrected notification assertions to reference the appropriate requesting user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->